### PR TITLE
Increase binary download timeout

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -221,7 +221,7 @@ where
 	P: AsRef<Path>
 {
 	let resp = ureq::get(source_url)
-		.timeout(std::time::Duration::from_secs(300))
+		.timeout(std::time::Duration::from_secs(1800))
 		.call()
 		.unwrap_or_else(|err| panic!("[ort] failed to download {source_url}: {err:?}"));
 


### PR DESCRIPTION
Hello, thank you to those who lead a wonderful project!

This PR is a workaround for cases where **downloading binaries gives a timeout error when the user is on a slow network environment**.