### PR TITLE
fix: warn on mismatched lib version instead of panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use std::{
 };
 
 use lazy_static::lazy_static;
+use tracing::warn;
 
 pub use self::environment::Environment;
 pub use self::error::{OrtApiError, OrtError, OrtResult};
@@ -86,13 +87,18 @@ lazy_static! {
 			let get_version_string: extern_system_fn! { unsafe fn () -> *const ffi::c_char } = (*base).GetVersionString.unwrap();
 			let version_string = get_version_string();
 			let version_string = CStr::from_ptr(version_string).to_string_lossy();
-			if !version_string.starts_with("1.14.") {
+			let lib_minor_version = version_string.split('.').nth(1).map(|x| x.parse::<u32>().unwrap_or(0)).unwrap_or(0);
+			if lib_minor_version < 14 {
 				panic!(
 					"ort 1.14 is not compatible with the ONNX Runtime binary found at `{}`; expected GetVersionString to return '1.14.x', but got '{version_string}'",
 					**G_ORT_DYLIB_PATH
 				);
+			} else if lib_minor_version > 14 {
+				warn!(
+					"ort 1.14 may have compatibility issues with the ONNX Runtime binary found at `{}`; expected GetVersionString to return '1.14.x', but got '{version_string}'",
+					**G_ORT_DYLIB_PATH
+				);
 			}
-
 			let get_api: extern_system_fn! { unsafe fn(u32) -> *const sys::OrtApi } = (*base).GetApi.unwrap();
 			let api: *const sys::OrtApi = get_api(sys::ORT_API_VERSION);
 			Arc::new(Mutex::new(AtomicPtr::new(api as *mut sys::OrtApi)))


### PR DESCRIPTION
Great lib thanks, for local development on an M1 mac (aarch64) to speed things up I need to build from the master branch of libonnxruntime (1.15.0) as I get errors trying to build 1.14.1. This all works fine if I get rid of the panic below, across ~10 models I get the same results through `coreml` as I do on the CPU.

For your consideration below to change to a warning instead of panic, so we can package a later version of libonnxruntime if it's working.