### PR TITLE
Fix x86 target compilation

### DIFF
--- a/src/execution_providers.rs
+++ b/src/execution_providers.rs
@@ -285,9 +285,9 @@ pub(crate) fn apply_execution_providers(options: *mut sys::OrtSessionOptions, ex
 			#[cfg(any(feature = "load-dynamic", feature = "rocm"))]
 			"ROCmExecutionProvider" => {
 				#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
-				let gpu_mem_limit= std::os::raw::c_ulong::MAX;
+				let gpu_mem_limit = std::os::raw::c_ulong::MAX;
 				#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-				let gpu_mem_limit= usize::MAX;
+				let gpu_mem_limit = usize::MAX;
 				let rocm_options = sys::OrtROCMProviderOptions {
 					device_id: 0,
 					miopen_conv_exhaustive_search: 0,

--- a/src/execution_providers.rs
+++ b/src/execution_providers.rs
@@ -284,10 +284,14 @@ pub(crate) fn apply_execution_providers(options: *mut sys::OrtSessionOptions, ex
 			}
 			#[cfg(any(feature = "load-dynamic", feature = "rocm"))]
 			"ROCmExecutionProvider" => {
+				#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+				let gpu_mem_limit= std::os::raw::c_ulong::MAX;
+				#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+				let gpu_mem_limit= usize::MAX;
 				let rocm_options = sys::OrtROCMProviderOptions {
 					device_id: 0,
 					miopen_conv_exhaustive_search: 0,
-					gpu_mem_limit: std::os::raw::c_ulong::MAX,
+					gpu_mem_limit,
 					arena_extend_strategy: 0,
 					do_copy_in_default_stream: 1,
 					has_user_compute_stream: 0,


### PR DESCRIPTION
Hello,

I believe recent changes (https://github.com/pykeio/ort/pull/48) have broken x86 compilation. The current bindings are currently setting a special case for `x86` targets, replacing `size_t` by `usize` when generating the bindings: https://github.com/pykeio/ort/blob/254a5ce8f059f28356393c2c72fae8df6fde5457/build.rs#L660 resulting in https://github.com/pykeio/ort/blob/254a5ce8f059f28356393c2c72fae8df6fde5457/src/bindings/linux/x86_64/bindings.rs#L376

This means that `sys::OrtROCMProviderOptions` expects a `usize` for the `gpu_mem_limit` field rather than a `c_ulong`. The current code does not compile with the following error message:
```
 gpu_mem_limit,
 ^^^^^^^^^^^^^^ expected usize, found u32
```
This PR handles the special `x86` architecture case, and should hopefully maintain M1 mac compatibility from the previous PR.

This could also be fixed by casting into the expected type with:
```rust
let rocm_options = sys::OrtROCMProviderOptions {
        [...]
	gpu_mem_limit: gpu_mem_limit.try_into().unwrap(),
        [...]
};
```

Please let me know what your preferred solution would be, happy to amend the change request