### PR TITLE
WIP - Use ArcArray to remove copy

### DIFF
--- a/src/session/input.rs
+++ b/src/session/input.rs
@@ -4,32 +4,32 @@ use smallvec::SmallVec;
 
 use crate::{IoBinding, Value};
 
-pub enum SessionInputs<'s, 'v> {
+pub enum SessionInputs<'s> {
 	IoBinding(IoBinding<'s>),
-	ValueMap(HashMap<&'static str, Value<'v>>),
-	ValueVec(SmallVec<[Value<'v>; 4]>)
+	ValueMap(HashMap<&'static str, Value>),
+	ValueVec(SmallVec<[Value; 4]>)
 }
 
-impl<'s, 'v> From<IoBinding<'s>> for SessionInputs<'s, 'v> {
+impl<'s> From<IoBinding<'s>> for SessionInputs<'s> {
 	fn from(val: IoBinding<'s>) -> Self {
 		SessionInputs::IoBinding(val)
 	}
 }
 
-impl<'s, 'v> From<HashMap<&'static str, Value<'v>>> for SessionInputs<'s, 'v> {
-	fn from(val: HashMap<&'static str, Value<'v>>) -> Self {
+impl<'s> From<HashMap<&'static str, Value>> for SessionInputs<'s> {
+	fn from(val: HashMap<&'static str, Value>) -> Self {
 		SessionInputs::ValueMap(val)
 	}
 }
 
-impl<'s, 'v> From<Vec<Value<'v>>> for SessionInputs<'s, 'v> {
-	fn from(val: Vec<Value<'v>>) -> Self {
+impl<'s> From<Vec<Value>> for SessionInputs<'s> {
+	fn from(val: Vec<Value>) -> Self {
 		SessionInputs::ValueVec(val.into())
 	}
 }
 
-impl<'s, 'v> From<SmallVec<[Value<'v>; 4]>> for SessionInputs<'s, 'v> {
-	fn from(val: SmallVec<[Value<'v>; 4]>) -> Self {
+impl<'s> From<SmallVec<[Value; 4]>> for SessionInputs<'s> {
+	fn from(val: SmallVec<[Value; 4]>) -> Self {
 		SessionInputs::ValueVec(val)
 	}
 }

--- a/src/session/output.rs
+++ b/src/session/output.rs
@@ -5,13 +5,13 @@ use std::{
 
 use crate::Value;
 
-pub struct SessionOutputs<'s> {
-	map: HashMap<String, Value<'s>>,
+pub struct SessionOutputs {
+	map: HashMap<String, Value>,
 	idxs: Vec<String>
 }
 
-impl<'s> SessionOutputs<'s> {
-	pub(crate) fn new(output_names: Vec<String>, output_values: impl IntoIterator<Item = Value<'s>>) -> Self {
+impl SessionOutputs {
+	pub(crate) fn new(output_names: Vec<String>, output_values: impl IntoIterator<Item = Value>) -> Self {
 		let map = output_names.iter().cloned().zip(output_values).collect();
 		Self { map, idxs: output_names }
 	}
@@ -24,36 +24,36 @@ impl<'s> SessionOutputs<'s> {
 	}
 }
 
-impl<'s> Deref for SessionOutputs<'s> {
-	type Target = HashMap<String, Value<'s>>;
+impl Deref for SessionOutputs {
+	type Target = HashMap<String, Value>;
 
 	fn deref(&self) -> &Self::Target {
 		&self.map
 	}
 }
 
-impl<'s> DerefMut for SessionOutputs<'s> {
+impl DerefMut for SessionOutputs {
 	fn deref_mut(&mut self) -> &mut Self::Target {
 		&mut self.map
 	}
 }
 
-impl<'s> Index<&str> for SessionOutputs<'s> {
-	type Output = Value<'s>;
+impl Index<&str> for SessionOutputs {
+	type Output = Value;
 	fn index(&self, index: &str) -> &Self::Output {
 		self.map.get(index).unwrap()
 	}
 }
 
-impl<'s> Index<String> for SessionOutputs<'s> {
-	type Output = Value<'s>;
+impl Index<String> for SessionOutputs {
+	type Output = Value;
 	fn index(&self, index: String) -> &Self::Output {
 		self.map.get(index.as_str()).unwrap()
 	}
 }
 
-impl<'s> Index<usize> for SessionOutputs<'s> {
-	type Output = Value<'s>;
+impl Index<usize> for SessionOutputs {
+	type Output = Value;
 	fn index(&self, index: usize) -> &Self::Output {
 		self.map.get(&self.idxs[index]).unwrap()
 	}


### PR DESCRIPTION
This isn't that well thought through - but it worked in my testing. Still missing the `.as_standard_layout` call - I assume calling `.to_shared` on the `CowArray` resolves that, but I haven't checked.

```rust
let data1 = vec![0_u8; 16*1536*2048];
let mut inp1 = ArcArray::from_shape_vec((16, 1, 1536, 2048), data1).unwrap().into_dyn();
let start_ptr = inp1.as_mut_ptr();
c.bench_function(name, |b| {
    b.iter(|| {
        assert_eq!(start_ptr, inp1.as_mut_ptr());
        let input_tensor = Value::from_array(None, &mut inp1).unwrap();
        bind.bind_input("images", input_tensor).unwrap();
        let _ = bind.run().unwrap();
    })
});
```