### PR TITLE
docs: Fixed a broken link in the doc comments of session.rs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -77,7 +77,7 @@ jobs:
         run: cargo install cargo-tarpaulin
       - name: Generate code coverage
         run: |
-          cargo tarpaulin --features fetch-models --verbose --timeout 120 --out Xml
+          cargo tarpaulin --features fetch-models --verbose --timeout 120 --out xml
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2
         with:

--- a/src/session.rs
+++ b/src/session.rs
@@ -563,7 +563,7 @@ impl Drop for SessionPointerHolder {
 	}
 }
 
-/// Type storing the session information, built from an [`Environment`](environment/struct.Environment.html)
+/// Type storing the session information, built from an [`Environment`](crate::environment::Environment)
 #[derive(Debug)]
 pub struct Session {
 	#[allow(dead_code)]


### PR DESCRIPTION
Fixed a broken link.

Check `Environment` link in `Type storing the session information, built from an Environment`.

https://docs.rs/ort/1.15.4/ort/session/struct.Session.html