### PR TITLE
feat: add `with_enable_ort_custom_ops` to use builtin extensions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -344,12 +344,12 @@ fn system_strategy() -> (PathBuf, bool) {
 		println!("cargo:rustc-link-lib=static=onnxruntime");
 		needs_link = false;
 	} else {
-		let static_configs: Vec<(PathBuf, PathBuf, Box<dyn Fn(PathBuf, &String) -> PathBuf>)> = vec![
-			(lib_dir.join(&profile), lib_dir.join("_deps"), Box::new(|p: PathBuf, profile| p.join(profile))),
-			(lib_dir.clone(), lib_dir.parent().unwrap().join("_deps"), Box::new(|p: PathBuf, _| p)),
-			(lib_dir.join("onnxruntime"), lib_dir.join("_deps"), Box::new(|p: PathBuf, _| p)),
+		let static_configs: Vec<(PathBuf, PathBuf, PathBuf, Box<dyn Fn(PathBuf, &String) -> PathBuf>)> = vec![
+			(lib_dir.join(&profile), lib_dir.join("lib"), lib_dir.join("_deps"), Box::new(|p: PathBuf, profile| p.join(profile))),
+			(lib_dir.clone(), lib_dir.join("lib"), lib_dir.parent().unwrap().join("_deps"), Box::new(|p: PathBuf, _| p)),
+			(lib_dir.join("onnxruntime"), lib_dir.join("onnxruntime").join("lib"), lib_dir.join("_deps"), Box::new(|p: PathBuf, _| p)),
 		];
-		for (lib_dir, external_lib_dir, transform_dep) in static_configs {
+		for (lib_dir, extension_lib_dir, external_lib_dir, transform_dep) in static_configs {
 			if lib_dir.join(platform_format_lib("onnxruntime_common")).exists() {
 				add_search_dir(&lib_dir);
 
@@ -361,6 +361,13 @@ fn system_strategy() -> (PathBuf, bool) {
 					} else {
 						panic!("[ort] unable to find ONNX Runtime library: {}", lib_path.display());
 					}
+				}
+
+				if extension_lib_dir.exists() {
+					add_search_dir(&extension_lib_dir);
+					println!("cargo:rustc-link-lib=static=ortcustomops");
+					println!("cargo:rustc-link-lib=static=ocos_operators");
+					println!("cargo:rustc-link-lib=static=noexcep_operators");
 				}
 
 				if target_arch == "wasm32" {

--- a/src/session.rs
+++ b/src/session.rs
@@ -271,6 +271,12 @@ impl SessionBuilder {
 		Ok(self)
 	}
 
+	pub fn with_enable_ort_custom_ops(self) -> OrtResult<Self> {
+		let status = ortsys![unsafe EnableOrtCustomOps(self.session_options_ptr)];
+		status_to_result(status).map_err(OrtError::CreateSessionOptions)?;
+		Ok(self)
+	}
+
 	/// Downloads a pre-trained ONNX model from the [ONNX Model Zoo](https://github.com/onnx/models) and builds the session.
 	#[cfg(feature = "fetch-models")]
 	pub fn with_model_downloaded<M>(self, model: M) -> OrtResult<Session>


### PR DESCRIPTION
Onnxruntime can be built with `--use_extensions` to include onnxruntime-extensions inside. In this case, we need to call `EnableOrtCustomOps` for sessions that need ops in extensions. Also, the build.rs is updated to include libraries for custom ops.