### PR TITLE
Change field order to drop Environment last

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -60,13 +60,15 @@ use crate::{io_binding::IoBinding, value::Value};
 /// # }
 /// ```
 pub struct SessionBuilder {
-	env: Arc<Environment>,
 	session_options_ptr: *mut sys::OrtSessionOptions,
 
 	allocator: AllocatorType,
 	memory_type: MemType,
 	custom_runtime_handles: Vec<*mut std::os::raw::c_void>,
-	execution_providers: Vec<ExecutionProvider>
+	execution_providers: Vec<ExecutionProvider>,
+
+	// env must be last to drop it after everything else
+	env: Arc<Environment>
 }
 
 impl Debug for SessionBuilder {
@@ -566,14 +568,16 @@ impl Drop for SessionPointerHolder {
 /// Type storing the session information, built from an [`Environment`](crate::environment::Environment)
 #[derive(Debug)]
 pub struct Session {
-	#[allow(dead_code)]
-	env: Arc<Environment>,
 	pub(crate) session_ptr: Arc<SessionPointerHolder>,
 	allocator_ptr: *mut sys::OrtAllocator,
 	/// Information about the ONNX's inputs as stored in loaded file
 	pub inputs: Vec<Input>,
 	/// Information about the ONNX's outputs as stored in loaded file
-	pub outputs: Vec<Output>
+	pub outputs: Vec<Output>,
+
+	// env must be last to drop it after everything else
+	#[allow(dead_code)]
+	env: Arc<Environment>
 }
 
 /// A [`Session`] with data stored in-memory.


### PR DESCRIPTION
This changes the order of the field to drop Environment after everything else.

The current code gets stuck, randomly but steadily, during the drop. What happened is that `SessionPointerHolder` held by the session is dropped after the `Environment`, and this seems to cause it to be blocked indefinitely.

This is an example code that shows that the program gets stuck. This happens with both ort 1.15 and 1.16. It happens with different models.

```rust
use ort::{
    environment::Environment,
    session::{Session, SessionBuilder},
};

pub struct Model {
    _session: Session,
}

impl Model {
    fn new() -> Self {
        let environment = Environment::builder().build().unwrap().into_arc();
        let session = SessionBuilder::new(&environment)
            .unwrap()
            .with_model_from_file("./model.onnx")
            .unwrap();

        Model {
            _session: session,
        }
    }
}

fn main() {
    Model::new();
}
```

With the proposed fix, it doesn't get stuck anymore. This could also be achieved by adding an env field after `session` in `Model`, but since `Session` already holds an `Environment`, it shouldn't be needed.