### PR TITLE
Add iOS and Android support.

### DIFF
--- a/ort-sys/build.rs
+++ b/ort-sys/build.rs
@@ -117,7 +117,7 @@ fn static_link_prerequisites() {
 	if target_os == "macos" || target_os == "ios" {
 		println!("cargo:rustc-link-lib=c++");
 		println!("cargo:rustc-link-lib=framework=Foundation");
-	} else if target_os == "linux" {
+	} else if target_os == "linux" || target_os == "android" {
 		println!("cargo:rustc-link-lib=stdc++");
 	}
 }


### PR DESCRIPTION
1. Add a environment: ORT_LIB_PROFILE, for profile name of iOS target.
2. Add link options for iOS and Android.
3. Check extension lib dir.

It works fine on my mobile application with iOS and Android devices.