### PR TITLE
Export `EnvironmentGlobalThreadPoolOptions`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ use tracing::Level;
 
 #[cfg(feature = "load-dynamic")]
 pub use self::environment::init_from;
-pub use self::environment::{init, EnvironmentBuilder};
+pub use self::environment::{init, EnvironmentBuilder, EnvironmentGlobalThreadPoolOptions};
 #[cfg(feature = "fetch-models")]
 #[cfg_attr(docsrs, doc(cfg(feature = "fetch-models")))]
 pub use self::error::FetchModelError;


### PR DESCRIPTION
Makes `with_global_thread_pool` usable by external packages.