### PR TITLE
Adds Rust Api for Basic `RunOptions` Support

### DIFF
--- a/examples/gpt2/examples/gpt2-no-ndarray.rs
+++ b/examples/gpt2/examples/gpt2-no-ndarray.rs
@@ -50,7 +50,8 @@ fn main() -> ort::Result<()> {
 		// Raw tensor construction takes a tuple of (dimensions, data).
 		// The model expects our input to have shape [B, _, S]
 		let input = (vec![1, 1, tokens.len() as i64], Arc::clone(&tokens));
-		let outputs = session.run(inputs![input]?)?;
+		let run_options = None;
+		let outputs = session.run(inputs![input]?, run_options)?;
 		let (dim, mut probabilities) = outputs["output1"].extract_raw_tensor()?;
 
 		// The output tensor will have shape [B, _, S + 1, V]

--- a/examples/gpt2/examples/gpt2.rs
+++ b/examples/gpt2/examples/gpt2.rs
@@ -50,7 +50,8 @@ fn main() -> ort::Result<()> {
 
 	for _ in 0..GEN_TOKENS {
 		let array = tokens.view().insert_axis(Axis(0)).insert_axis(Axis(1));
-		let outputs = session.run(inputs![array]?)?;
+		let run_options = None;
+		let outputs = session.run(inputs![array]?, run_options)?;
 		let generated_tokens: Tensor<f32> = outputs["output1"].extract_tensor()?;
 		let generated_tokens = generated_tokens.view();
 

--- a/examples/yolov8/examples/yolov8.rs
+++ b/examples/yolov8/examples/yolov8.rs
@@ -62,7 +62,8 @@ fn main() -> ort::Result<()> {
 	let model = Session::builder()?.with_model_downloaded(YOLOV8M_URL)?;
 
 	// Run YOLOv8 inference
-	let outputs: SessionOutputs = model.run(inputs!["images" => input.view()]?)?;
+	let run_options = None;
+	let outputs: SessionOutputs = model.run(inputs!["images" => input.view()]?, run_options)?;
 	let output = outputs["output0"].extract_tensor::<f32>().unwrap().view().t().into_owned();
 
 	let mut boxes = Vec::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,6 +105,15 @@ pub enum Error {
 	/// Error occurred when extracting string data from an ONNX tensor
 	#[error("Failed to get tensor string data: {0}")]
 	GetStringTensorContent(ErrorInternal),
+	/// Error occurred when creating run options.
+	#[error("Failed to create run options: {0}")]
+	CreateRunOptions(ErrorInternal),
+	/// Error occurred when terminating run options.
+	#[error("Failed to terminate run options: {0}")]
+	RunOptionsSetTerminate(ErrorInternal),
+	/// Error occurred when unterminating run options.
+	#[error("Failed to unterminate run options: {0}")]
+	RunOptionsUnsetTerminate(ErrorInternal),
 	/// Error occurred when converting data to a String
 	#[error("Data was not UTF-8: {0}")]
 	StringFromUtf8Error(#[from] string::FromUtf8Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub use self::execution_providers::*;
 pub use self::io_binding::IoBinding;
 pub use self::memory::{AllocationDevice, Allocator, MemoryInfo};
 pub use self::metadata::ModelMetadata;
-pub use self::session::{InMemorySession, Session, SessionBuilder, SessionInputs, SessionOutputs, SharedSessionInner};
+pub use self::session::{InMemorySession, RunOptions, Session, SessionBuilder, SessionInputs, SessionOutputs, SharedSessionInner};
 #[cfg(feature = "ndarray")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ndarray")))]
 pub use self::tensor::{ArrayExtensions, ArrayViewHolder, Tensor, TensorData};

--- a/src/session/input.rs
+++ b/src/session/input.rs
@@ -44,7 +44,8 @@ impl<'i, const N: usize> From<[Value; N]> for SessionInputs<'i, N> {
 /// # use ort::{GraphOptimizationLevel, Session};
 /// # fn main() -> Result<(), Box<dyn Error>> {
 /// let mut session = Session::builder()?.with_model_from_file("model.onnx")?;
-/// let _ = session.run(ort::inputs![Array1::from_vec(vec![1, 2, 3, 4, 5])]?);
+/// let run_options = None;
+/// let _ = session.run(ort::inputs![Array1::from_vec(vec![1, 2, 3, 4, 5])]?, run_options);
 /// # Ok(())
 /// # }
 /// ```
@@ -57,8 +58,9 @@ impl<'i, const N: usize> From<[Value; N]> for SessionInputs<'i, N> {
 /// # use ort::{GraphOptimizationLevel, Session};
 /// # fn main() -> Result<(), Box<dyn Error>> {
 /// let mut session = Session::builder()?.with_model_from_file("model.onnx")?;
+/// let run_options = None;
 /// let _ = session.run(ort::inputs! {
-/// 	"tokens" => Array1::from_vec(vec![1, 2, 3, 4, 5])
+/// 	"tokens" => Array1::from_vec(vec![1, 2, 3, 4, 5], run_options)
 /// }?);
 /// # Ok(())
 /// # }

--- a/tests/mnist.rs
+++ b/tests/mnist.rs
@@ -41,7 +41,8 @@ fn mnist_5() -> ort::Result<()> {
 	});
 
 	// Perform the inference
-	let outputs = session.run(inputs![array]?)?;
+	let run_options = None;
+	let outputs = session.run(inputs![array]?, run_options)?;
 
 	let output: Tensor<_> = outputs[0].extract_tensor()?;
 	let mut probabilities: Vec<(usize, f32)> = output.view().softmax(ndarray::Axis(1)).iter().copied().enumerate().collect::<Vec<_>>();

--- a/tests/squeezenet.rs
+++ b/tests/squeezenet.rs
@@ -66,7 +66,8 @@ fn squeezenet_mushroom() -> ort::Result<()> {
 	}
 
 	// Perform the inference
-	let outputs = session.run(inputs![array]?)?;
+	let run_options = None;
+	let outputs = session.run(inputs![array]?, run_options)?;
 
 	// Downloaded model does not have a softmax as final layer; call softmax on second axis
 	// and iterate on resulting probabilities, creating an index to later access labels.

--- a/tests/upsample.rs
+++ b/tests/upsample.rs
@@ -66,7 +66,8 @@ fn upsample() -> ort::Result<()> {
 	let array = convert_image_to_cow_array(&image_buffer);
 
 	// Perform the inference
-	let outputs = session.run(inputs![&array]?)?;
+	let run_options = None;
+	let outputs = session.run(inputs![&array]?, run_options)?;
 
 	assert_eq!(outputs.len(), 1);
 	let output: Tensor<f32> = outputs[0].extract_tensor()?;
@@ -103,7 +104,8 @@ fn upsample_with_ort_model() -> ort::Result<()> {
 	let array = convert_image_to_cow_array(&image_buffer);
 
 	// Perform the inference
-	let outputs = session.run(inputs![&array]?)?;
+	let run_options = None;
+	let outputs = session.run(inputs![&array]?, run_options)?;
 
 	assert_eq!(outputs.len(), 1);
 	let output: Tensor<f32> = outputs[0].extract_tensor()?;

--- a/tests/vectorizer.rs
+++ b/tests/vectorizer.rs
@@ -25,7 +25,8 @@ fn vectorizer() -> ort::Result<()> {
 	let input_tensor_values = inputs![Value::from_string_array(session.allocator(), &array)?]?;
 
 	// Perform the inference
-	let outputs = session.run(input_tensor_values)?;
+	let run_options = None;
+	let outputs = session.run(input_tensor_values, run_options)?;
 	assert_eq!(
 		*outputs[0].extract_tensor::<f32>()?.view(),
 		ArrayD::from_shape_vec(IxDyn(&[1, 9]), vec![0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])


### PR DESCRIPTION
The PR adds basic functionality to cancel active runs in a session via `RunOptions` Api.

Corresponding Rust methods are added for the following ONNX Runtime functions:
- [CreateRunOptions()](
https://onnxruntime.ai/docs/api/c/struct_ort_api.html#a87ba125ce92a1ecfeb3135d85287edfd),
- [RunOptionsSetTerminate()](
https://onnxruntime.ai/docs/api/c/struct_ort_api.html#ac2a08cac0a657604bd5899e0d1a13675),
- [RunOptionsUnsetTerminate()](
https://onnxruntime.ai/docs/api/c/struct_ort_api.html#ae12dd88ad92784b52db5455901bc31fd),
- [ReleaseRunOptions()](
https://onnxruntime.ai/docs/api/c/struct_ort_api.html#ab09e362ad76fa2d71f23d7860d5a851e),

Corresponding Rust methods' signature changed to accept an additional `Optional<Arc<RunOptions>>` for the following ONNX Runtime functions:
- [Run()](
https://onnxruntime.ai/docs/api/c/struct_ort_api.html#ad8b12cad4160d43da92f49191cd91895),
- [RunWithBinding()](
https://onnxruntime.ai/docs/api/c/struct_ort_api.html#ab61526567b2a869233d6c7e575317b99)

- [ ] Add tests.

Closes #136.
