### PR TITLE
fix: do not lock api pointer

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -20,7 +20,7 @@ use std::{path::PathBuf, time::Duration};
 #[cfg(feature = "fetch-models")]
 use super::error::FetchModelError;
 use super::{
-	api, char_p_to_string,
+	char_p_to_string,
 	environment::get_environment,
 	error::{assert_non_null_pointer, assert_null_pointer, status_to_result, Error, ErrorInternal, Result},
 	execution_providers::{apply_execution_providers, ExecutionProviderDispatch},
@@ -697,12 +697,12 @@ mod dangerous {
 	};
 
 	pub(super) fn extract_inputs_count(session_ptr: *mut ort_sys::OrtSession) -> Result<usize> {
-		let f = api().SessionGetInputCount.unwrap();
+		let f = ortsys![unsafe SessionGetInputCount];
 		extract_io_count(f, session_ptr)
 	}
 
 	pub(super) fn extract_outputs_count(session_ptr: *mut ort_sys::OrtSession) -> Result<usize> {
-		let f = api().SessionGetOutputCount.unwrap();
+		let f = ortsys![unsafe SessionGetOutputCount];
 		extract_io_count(f, session_ptr)
 	}
 
@@ -721,12 +721,12 @@ mod dangerous {
 	}
 
 	fn extract_input_name(session_ptr: *mut ort_sys::OrtSession, allocator_ptr: *mut ort_sys::OrtAllocator, i: ort_sys::size_t) -> Result<String> {
-		let f = api().SessionGetInputName.unwrap();
+		let f = ortsys![unsafe SessionGetInputName];
 		extract_io_name(f, session_ptr, allocator_ptr, i)
 	}
 
 	fn extract_output_name(session_ptr: *mut ort_sys::OrtSession, allocator_ptr: *mut ort_sys::OrtAllocator, i: ort_sys::size_t) -> Result<String> {
-		let f = api().SessionGetOutputName.unwrap();
+		let f = ortsys![unsafe SessionGetOutputName];
 		extract_io_name(f, session_ptr, allocator_ptr, i)
 	}
 
@@ -764,14 +764,14 @@ mod dangerous {
 
 	pub(super) fn extract_input(session_ptr: *mut ort_sys::OrtSession, allocator_ptr: *mut ort_sys::OrtAllocator, i: usize) -> Result<Input> {
 		let input_name = extract_input_name(session_ptr, allocator_ptr, i as _)?;
-		let f = api().SessionGetInputTypeInfo.unwrap();
+		let f = ortsys![unsafe SessionGetInputTypeInfo];
 		let input_type = extract_io(f, session_ptr, i as _)?;
 		Ok(Input { name: input_name, input_type })
 	}
 
 	pub(super) fn extract_output(session_ptr: *mut ort_sys::OrtSession, allocator_ptr: *mut ort_sys::OrtAllocator, i: usize) -> Result<Output> {
 		let output_name = extract_output_name(session_ptr, allocator_ptr, i as _)?;
-		let f = api().SessionGetOutputTypeInfo.unwrap();
+		let f = ortsys![unsafe SessionGetOutputTypeInfo];
 		let output_type = extract_io(f, session_ptr, i as _)?;
 		Ok(Output { name: output_name, output_type })
 	}


### PR DESCRIPTION
The previous `api()` behavior was a remnant from `nbigaouette/onnxruntime-rs`. I am not sure why we need a `Mutex` here, or why `api()` unsafely dereferences the pointer, or why we need to `get_mut()` on the `AtomicPtr`. Refactoring the code to forego a `Mutex` and do a regular atomic load on the pointer fixes #157 (more on Discord), in which a SIGSEGV was encountered when multiple sessions were being created simultaneously from different threads.