### PR TITLE
Add Supabase to Projects using ort

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - **[pyke Diffusers](https://github.com/pykeio/diffusers)** uses `ort` for efficient Stable Diffusion image generation on both CPUs & GPUs.
 - **[edge-transformers](https://github.com/npc-engine/edge-transformers)** uses `ort` for accelerated transformer model inference at the edge.
 - **[Ortex](https://github.com/relaypro-open/ortex)** uses `ort` for safe ONNX Runtime bindings in Elixir.
+- **[Supabase](https://github.com/relaypro-open/ortex)** uses `ort` to remove cold starts for their edge functions using ONNX runtimes.
 
 ## 🌠 Sponsor `ort`
 <a href="https://opencollective.com/pyke-osai">


### PR DESCRIPTION
Supabase recently announced their support for AI Interference on edge functions. Their blog post mentions they use ort to solve cold start issue. So added Supabase to projects using ort section.

https://supabase.com/blog/ai-inference-now-available-in-supabase-edge-functions#technical-architecture