### PR TITLE
Add Lantern to Projects using ort

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - **[pyke Diffusers](https://github.com/pykeio/diffusers)** uses `ort` for efficient Stable Diffusion image generation on both CPUs & GPUs.
 - **[edge-transformers](https://github.com/npc-engine/edge-transformers)** uses `ort` for accelerated transformer model inference at the edge.
 - **[Ortex](https://github.com/relaypro-open/ortex)** uses `ort` for safe ONNX Runtime bindings in Elixir.
+- **[Lantern](https://github.com/lanterndata/lantern_extras)** uses `ort` to provide embedding model inference inside Postgres.
 
 ## 🌠 Sponsor `ort`
 <a href="https://opencollective.com/pyke-osai">


### PR DESCRIPTION
We at [Lantern](https://lantern.dev/) are using `ort` to provide embedding model inference inside the Postgres and also high performance embedding generation over existing data using batching.

You can find our implementation [here](https://github.com/lanterndata/lantern_extras/blob/main/lantern_cli/src/embeddings/core/ort_runtime.rs)
And the documentation [here](https://lantern.dev/docs/develop/generate)