### PR TITLE
Improve Build Flexibility with `pkg-config` for Better Dynamic Linking

### DIFF
--- a/docs/setup/linking.mdx
+++ b/docs/setup/linking.mdx
@@ -124,7 +124,7 @@ How to use dynamic linking configuration with `pkg-config`:
                 brew install pkg-config
                 ```
             </Tab>
-            <Tab title="macOS">
+            <Tab title="Windows">
                 ```shell
                 pacman -Syu
                 pacman -S pkg-config
@@ -142,6 +142,6 @@ How to use dynamic linking configuration with `pkg-config`:
 2. Setting Link Paths: The `pkg-config` tool provides a list of directories where the linker can find the binary files of libraries (`*.so`, `*.dll`, `*.dylib`). This is crucial because it ensures that the linker knows where to look for the libraries, which might not be in the default library search paths of the system. This is important when libraries are installed in non-standard locations.
 3. Specifying Libraries to Link Against: `pkg-config` also specifies the exact names of the libraries to link against. This precise specification prevents errors that could arise from linking against incorrect library versions or similar libraries with different names. It ensures that the build process is both accurate and reliable.
 
-#### How It Works?
+#### How it works?
 - Probing Libraries: `pkg-config` probes the installed libraries on the system using the library's package name, in this case `libonnxruntime` for ONNX Runtime. If the library is found, `pkg-config` retrieves the necessary compilation and linking information.
 - Extracting and Applying Configurations: The tool extracts configuration details such as library paths (where the libraries are located) and library names (which libraries to link against). These details are then used to set the appropriate flags for the Rust compiler and linker, ensuring that they can find and link the required libraries correctly.

--- a/docs/setup/linking.mdx
+++ b/docs/setup/linking.mdx
@@ -104,3 +104,44 @@ To configure rpath, you'll need to:
         </Tabs>
     </Step>
 </Steps>
+
+### Easy Dynamic Linking Configuration With `pkg-config`
+When working with external C or C++ libraries in Rust such as ONNX Runtime, `pkg-config` serves as a powerful tool to handle the configuration of linking paths and library dependencies. This approach is especially valuable in complex build environments. If your system has `pkg-config` installed and ONNX Runtime is registered with `pkg-config`, you can leverage this to simplify the linking process.
+
+How to use dynamic linking configuration with `pkg-config`:
+<Steps>
+    <Step title="Ensure `pkg-config` is installed on your system.">
+        <Tabs>
+            <Tab title="Linux">
+                Ubuntu
+                ```shell
+                sudo apt-get update
+                sudo apt-get install pkg-config
+                ```
+            </Tab>
+            <Tab title="macOS">
+                ```shell
+                brew install pkg-config
+                ```
+            </Tab>
+            <Tab title="macOS">
+                ```shell
+                pacman -Syu
+                pacman -S pkg-config
+                ```
+            </Tab>
+        </Tabs>
+    </Step>
+    </Step>
+        After installing `pkg-config`, you may need to set the `PKG_CONFIG_PATH` environment variable if `pkg-config` does not automatically find all installed libraries. This variable tells `pkg-config` where to look for its `.pc` files which store the package information.
+    </Step>
+</Steps>
+
+#### What does `pkg-config` automatically do for you?
+1. Automatic Configuration of Linker Flags: `pkg-config` automates the process of configuring the linker flags that are necessary to link a Rust application with external libraries. It retrieves and supplies the correct flags based on the library's configuration on the system, which typically includes paths to the library files and the names of the libraries themselves.
+2. Setting Link Paths: The `pkg-config` tool provides a list of directories where the linker can find the binary files of libraries (`*.so`, `*.dll`, `*.dylib`). This is crucial because it ensures that the linker knows where to look for the libraries, which might not be in the default library search paths of the system. This is important when libraries are installed in non-standard locations.
+3. Specifying Libraries to Link Against: `pkg-config` also specifies the exact names of the libraries to link against. This precise specification prevents errors that could arise from linking against incorrect library versions or similar libraries with different names. It ensures that the build process is both accurate and reliable.
+
+#### How It Works?
+- Probing Libraries: `pkg-config` probes the installed libraries on the system using the library's package name, in this case `libonnxruntime` for ONNX Runtime. If the library is found, `pkg-config` retrieves the necessary compilation and linking information.
+- Extracting and Applying Configurations: The tool extracts configuration details such as library paths (where the libraries are located) and library names (which libraries to link against). These details are then used to set the appropriate flags for the Rust compiler and linker, ensuring that they can find and link the required libraries correctly.

--- a/ort-sys/Cargo.toml
+++ b/ort-sys/Cargo.toml
@@ -44,3 +44,4 @@ ureq = { version = "2.1", optional = true, default-features = false, features = 
 tar = { version = "0.4", optional = true }
 flate2 = { version = "1.0", optional = true }
 sha2 = { version = "0.10", optional = true }
+pkg-config = "0.3.30"

--- a/ort-sys/build.rs
+++ b/ort-sys/build.rs
@@ -387,7 +387,7 @@ fn prepare_libort_dir() -> (PathBuf, bool) {
 fn try_setup_with_pkg_config() -> bool {
 	match pkg_config::Config::new().probe("libonnxruntime") {
 		Ok(lib) => {
-			println!("Using onnxruntime found by pkg-config: {:}", lib.display());
+			println!("Using onnxruntime found by pkg-config: {:?}", lib);
 			true
 		}
 		Err(_) => {

--- a/ort-sys/build.rs
+++ b/ort-sys/build.rs
@@ -186,11 +186,7 @@ fn prepare_libort_dir() -> (PathBuf, bool) {
 		let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap().to_lowercase();
 		let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap().to_lowercase();
 		let platform_format_lib = |a: &str| {
-			if target_os.contains("windows") {
-				format!("{}.lib", a)
-			} else {
-				format!("lib{}.a", a)
-			}
+			if target_os.contains("windows") { format!("{}.lib", a) } else { format!("lib{}.a", a) }
 		};
 
 		let mut profile = env::var(ORT_ENV_SYSTEM_LIB_PROFILE).unwrap_or_default();
@@ -322,11 +318,7 @@ fn prepare_libort_dir() -> (PathBuf, bool) {
 		{
 			let target = env::var("TARGET").unwrap().to_string();
 			let designator = if cfg!(any(feature = "cuda", feature = "tensorrt")) {
-				if lib_exists("cudart64_12.dll") || lib_exists("libcudart.so.12") {
-					"cu12"
-				} else {
-					"cu11"
-				}
+				if lib_exists("cudart64_12.dll") || lib_exists("libcudart.so.12") { "cu12" } else { "cu11" }
 			} else if cfg!(feature = "rocm") {
 				"rocm"
 			} else {

--- a/ort-sys/build.rs
+++ b/ort-sys/build.rs
@@ -379,7 +379,17 @@ fn prepare_libort_dir() -> (PathBuf, bool) {
 fn try_setup_with_pkg_config() -> bool {
 	match pkg_config::Config::new().probe("libonnxruntime") {
 		Ok(lib) => {
-			println!("Using onnxruntime found by pkg-config: {:?}", lib);
+			// Setting the link paths
+			for path in lib.link_paths {
+				println!("cargo:rustc-link-search=native={}", path.display());
+			}
+
+			// Setting the libraries to link against
+			for lib in lib.libs {
+				println!("cargo:rustc-link-lib={}", lib);
+			}
+
+			println!("Using onnxruntime found by pkg-config.");
 			true
 		}
 		Err(_) => {


### PR DESCRIPTION
#### Objective
The primary objective of this PR is to address the challenge of manually configuring environment variables when using system libraries in the `ort-sys` crate. This process can be error-prone and cumbersome, especially when ensuring compatibility across different development environments. By integrating `pkg-config`, it aims to automate and streamline the detection and configuration of the ONNX Runtime library and other dependencies, enhancing developer productivity and improving build consistency.

#### Motivation
Currently, developers/users need to manually set environment variables to configure the correct paths for linking system libraries. This manual setup not only slows down the development process but also introduces potential errors and inconsistencies across different platforms. Automating this setup through `pkg-config` will minimize human error, speed up the build process, and ensure that the correct library versions and configurations are used.

#### What Changes?
1. **Integration of `pkg-config`**:
   - Added `pkg-config` as a dependency in `Cargo.toml`.
   - Implemented a new function `try_setup_with_pkg_config()` in `build.rs`, which leverages `pkg-config` to automatically find and configure the necessary compiler and linker settings for the ONNX Runtime system lib.
   - If `pkg-config` finds the lib, it automatically sets up the build environment, in case it is not successful it uses the existing manual configuration.

3. **Dynamic Linking Enhancement**:
   - **Dynamic Libraries**: By leveraging `pkg-config`, the build script automates the process of configuring dynamic linker flags. 

#### Testing
- Tested it across multiple platforms (Linux and macOS) that it works with `pkg-config` and with the existing manual fallback

### Todo
- [x] Test on Windows
- [x] Update docs