### PR TITLE
Fix onnxruntime static library link when linking onto C/C++

### DIFF
--- a/ort-sys/build.rs
+++ b/ort-sys/build.rs
@@ -409,7 +409,15 @@ fn real_main(link: bool) {
 
 	if link {
 		if needs_link {
-			println!("cargo:rustc-link-lib=static=onnxruntime");
+			let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+			let static_lib_file_name = if target_os.contains("windows") { "onnxruntime.lib" } else { "libonnxruntime.a" };
+
+			let static_lib_path = lib_dir.join(static_lib_file_name);
+			if static_lib_path.exists() {
+				println!("cargo:rustc-link-lib=static=onnxruntime");
+			} else {
+				println!("cargo:rustc-link-lib=onnxruntime");
+			}
 			println!("cargo:rustc-link-search=native={}", lib_dir.display());
 		}
 

--- a/ort-sys/build.rs
+++ b/ort-sys/build.rs
@@ -409,7 +409,7 @@ fn real_main(link: bool) {
 
 	if link {
 		if needs_link {
-			println!("cargo:rustc-link-lib=onnxruntime");
+			println!("cargo:rustc-link-lib=static=onnxruntime");
 			println!("cargo:rustc-link-search=native={}", lib_dir.display());
 		}
 


### PR DESCRIPTION
### Issue
When building into a static library which then is linked to a C/C++ project, if you build by using
`cargo build --release`
the onnx runtime lib is not merged with the newly created library, and link errors arise, forcing you to link again the onnx runtime.

However, if you build by specifying the path to the libraries, such as 
`ORT_LIB_LOCATION=/path/to/lib cargo build --release`
no issues are present.
### Solution
Change the linking instructions for the default case where the downloaded onnx libraries are used, adding `static` instruction.
### Test
Tested on Linux x86_64, Ubuntu 22.04.4 LTS on WSL2
