### PR TITLE
Remove Error::Infaillible

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -29,11 +29,6 @@ impl<T> IntoStatus for Result<T, Error> {
 #[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum Error {
-	/// Workaround to get [`crate::inputs`] to accept `Value`s, since it will attempt to `Value::try_from` on provided
-	/// values, and the implementation `TryFrom<T> for T` uses `Infallible` as the error type.
-	#[error("unreachable")]
-	#[doc(hidden)]
-	Infallible,
 	/// An error occurred when converting an FFI C string to a Rust `String`.
 	#[error("Failed to construct Rust String")]
 	FfiStringConversion(ErrorInternal),
@@ -278,8 +273,8 @@ impl Error {
 }
 
 impl From<Infallible> for Error {
-	fn from(_: Infallible) -> Self {
-		Error::Infallible
+	fn from(e: Infallible) -> Self {
+		match e {}
 	}
 }
 


### PR DESCRIPTION
Not sure if it's welcome, just a small nitpick I had when trying your amazing library.

`Infaillible` type can never be instantiated so this error variant  is never actually used