### PR TITLE
examples(phi-3-vision): Optimize text generation performance using KV cache

### DIFF
--- a/examples/phi-3-vision/README.md
+++ b/examples/phi-3-vision/README.md
@@ -35,8 +35,8 @@ This example currently only supports single image input.
 The performance of ONNX-based LLM inference can be relatively slow, especially on CPU:
 
 - On an Apple M1 Pro:
-  - For image+text input (about 300 tokens): ~5 seconds per output token
-  - For text-only input (about 10 tokens): ~200ms per output token
+  - For image+text input (about 300 tokens): ~7 tokens/s
+  - For text-only input (about 10 tokens): ~5 tokens/s
 
 ## Run this Example
 


### PR DESCRIPTION
This PR significantly improves the performance of the phi-3-vision example by optimizing KV cache usage.

Key changes:
- Process only the newly generated token in each iteration
- Eliminate full input sequence reconstruction

The previous implementation of the phi-3-vision example was running much slower than intended. This update improves generation speed from minutes to seconds, making the example actually useful for demonstrating the model.
