### PR TITLE
fix: concurrent downloads again

### DIFF
--- a/ort-sys/build.rs
+++ b/ort-sys/build.rs
@@ -472,13 +472,14 @@ fn prepare_libort_dir() -> (PathBuf, bool) {
 				}
 				extract_tgz(&downloaded_file, &temp_extract_dir);
 				if should_rename {
-					match std::fs::rename(&temp_extract_dir, bin_extract_dir) {
+					match std::fs::rename(&temp_extract_dir, &bin_extract_dir) {
 						Ok(()) => {}
-						Err(e) => match e.kind() {
-							io::ErrorKind::AlreadyExists => {
+						Err(e) => {
+							if bin_extract_dir.exists() {
 								let _ = fs::remove_dir_all(temp_extract_dir);
+							} else {
+								panic!("failed to extract downloaded binaries: {e}");
 							}
-							_ => panic!("failed to extract downloaded binaries: {e}")
 						}
 					}
 				}


### PR DESCRIPTION
Fixup for <https://github.com/pykeio/ort/commit/eb51646860bc2fc5728d879bdf542c0537acc6ea> and <https://github.com/pykeio/ort/commit/effd7a76e627fdb5382d3092fb2b1f183d4ae90a>.

### Reason

The following code shows `PermissionDenied` on Windows, and `DirectoryNotEmpty` on Linux. I thought just checking the destination exists is simple and reliable.

```rs
let tmpdir = ::tempfile::tempdir()?;
let tmpdir = tmpdir.path();

std::fs::create_dir(tmpdir.join("dir1"))?;
std::fs::write(tmpdir.join("dir1").join("a.txt"), b"")?;

std::fs::create_dir(tmpdir.join("dir2"))?;
std::fs::write(tmpdir.join("dir2").join("a.txt"), b"")?;

let err = std::fs::rename(tmpdir.join("dir1"), tmpdir.join("dir2")).unwrap_err();
dbg!(err.kind());
```
