### PR TITLE
Alternative backends

### DIFF
--- a/.github/workflows/backends.yml
+++ b/.github/workflows/backends.yml
@@ -30,10 +30,17 @@ jobs:
       matrix:
         platform:
           - os: ubuntu-latest
-          - os: windows-latest
           - os: macos-15
     steps:
       - uses: actions/checkout@v4
+      - name: Install protoc
+        if: matrix.platform.os == 'macos-15'
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            apt update && apt install protobuf-compiler -y
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            brew install protobuf
+          fi
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/backends.yml
+++ b/.github/workflows/backends.yml
@@ -34,7 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install protoc
-        if: matrix.platform.os == 'macos-15'
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
             apt update && apt install protobuf-compiler -y

--- a/.github/workflows/backends.yml
+++ b/.github/workflows/backends.yml
@@ -1,0 +1,64 @@
+name: 🧩 Backends
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/backends.yml'
+      - 'src/**/*.rs'
+      - 'backends/**/*.rs'
+      - 'ort-sys/src/lib.rs'
+      - 'Cargo.toml'
+  pull_request:
+    paths:
+      - '.github/workflows/backends.yml'
+      - 'src/**/*.rs'
+      - 'backends/**/*.rs'
+      - 'ort-sys/src/lib.rs'
+      - 'Cargo.toml'
+env:
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_DEV_DEBUG: 0
+jobs:
+  candle:
+    name: Candle
+    runs-on: ${{ matrix.platform.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - os: ubuntu-latest
+          - os: windows-latest
+          - os: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Run tests
+        run: |
+          cargo test --manifest-path backends/candle/Cargo.toml --verbose -- --test-threads 1
+  tract:
+    name: Tract
+    runs-on: ${{ matrix.platform.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - os: ubuntu-latest
+          - os: windows-latest
+          - os: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Run tests
+        run: |
+          cargo test --manifest-path backends/tract/Cargo.toml --verbose -- --test-threads 1

--- a/.github/workflows/backends.yml
+++ b/.github/workflows/backends.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install protoc
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-            apt update && apt install protobuf-compiler -y
+            sudo apt-get update && sudo apt-get install protobuf-compiler -y
           elif [ "$RUNNER_OS" == "macOS" ]; then
             brew install protobuf
           fi

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Check fmt
         run: cargo fmt --all -- --check
       - name: Run clippy
-        run: cargo clippy -p ort --all-targets --workspace --features fetch-models
+        run: cargo clippy -p ort --all-targets --features fetch-models
   coverage:
     name: Code coverage
     runs-on: ubuntu-24.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
 	'ort-sys',
 	'backends/candle',
+	'backends/tract',
 	'examples/async-gpt2-api',
 	'examples/custom-ops',
 	'examples/gpt2',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
 	'ort-sys',
+	'backends/candle',
 	'examples/async-gpt2-api',
 	'examples/custom-ops',
 	'examples/gpt2',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,6 @@
 [workspace]
 members = [
 	'ort-sys',
-	'backends/candle',
-	'backends/tract',
 	'examples/async-gpt2-api',
 	'examples/custom-ops',
 	'examples/gpt2',
@@ -23,7 +21,11 @@ default-members = [
 	'examples/modnet',
 	'examples/sentence-transformers'
 ]
-exclude = [ 'examples/cudarc' ]
+exclude = [
+	'backends/candle',
+	'backends/tract',
+	'examples/cudarc'
+]
 
 [package]
 name = "ort"

--- a/backends/candle/Cargo.toml
+++ b/backends/candle/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "ort-candle"
+description = "ort + candle = 🦀 - An alternative backend for ort, powered by candle."
+version = "0.1.0+0.8.1"
+edition = "2021"
+rust-version = "1.70"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/pykeio/ort"
+homepage = "https://ort.pyke.io/"
+keywords = [ "machine-learning", "ai", "ml" , "sys"]
+categories = [ "algorithms", "mathematics", "science" ]
+authors = [
+	"pyke.io <contact@pyke.io>"
+]
+
+[lib]
+name = "ort_candle"
+path = "lib.rs"
+
+[dependencies]
+ort-sys = { version = "2.0.0-rc.9", path = "../../ort-sys", default-features = false }
+candle-core = { version = "0.8.1", default-features = false }
+candle-onnx = { version = "0.8.1" }

--- a/backends/candle/Cargo.toml
+++ b/backends/candle/Cargo.toml
@@ -23,6 +23,7 @@ path = "lib.rs"
 ort-sys = { version = "=2.0.0-rc.9", path = "../../ort-sys", default-features = false }
 candle-core = { version = "0.8.1", default-features = false }
 candle-onnx = { version = "0.8.1" }
+prost = { version = "0.12.1", default-features = false }
 
 [dev-dependencies]
 ort = { version = "=2.0.0-rc.9", path = "../../", default-features = false, features = [ "alternative-backend" ] }

--- a/backends/candle/Cargo.toml
+++ b/backends/candle/Cargo.toml
@@ -17,6 +17,8 @@ authors = [
 name = "ort_candle"
 path = "lib.rs"
 
+[features]
+
 [dependencies]
 ort-sys = { version = "=2.0.0-rc.9", path = "../../ort-sys", default-features = false }
 candle-core = { version = "0.8.1", default-features = false }
@@ -28,3 +30,6 @@ ort = { version = "=2.0.0-rc.9", path = "../../", default-features = false, feat
 [[test]]
 name = "memory"
 path = "tests/memory.rs"
+[[test]]
+name = "tensor"
+path = "tests/tensor.rs"

--- a/backends/candle/Cargo.toml
+++ b/backends/candle/Cargo.toml
@@ -26,7 +26,7 @@ candle-onnx = { version = "0.8.1" }
 prost = { version = "0.12.1", default-features = false }
 
 [dev-dependencies]
-ort = { version = "=2.0.0-rc.9", path = "../../", default-features = false, features = [ "alternative-backend" ] }
+ort = { version = "=2.0.0-rc.9", path = "../../", default-features = false, features = [ "alternative-backend", "fetch-models" ] }
 
 [[test]]
 name = "memory"

--- a/backends/candle/Cargo.toml
+++ b/backends/candle/Cargo.toml
@@ -18,6 +18,13 @@ name = "ort_candle"
 path = "lib.rs"
 
 [dependencies]
-ort-sys = { version = "2.0.0-rc.9", path = "../../ort-sys", default-features = false }
+ort-sys = { version = "=2.0.0-rc.9", path = "../../ort-sys", default-features = false }
 candle-core = { version = "0.8.1", default-features = false }
 candle-onnx = { version = "0.8.1" }
+
+[dev-dependencies]
+ort = { version = "=2.0.0-rc.9", path = "../../", default-features = false, features = [ "alternative-backend" ] }
+
+[[test]]
+name = "memory"
+path = "tests/memory.rs"

--- a/backends/candle/api.rs
+++ b/backends/candle/api.rs
@@ -1,0 +1,1954 @@
+#![allow(non_snake_case, unused)]
+
+use std::{ffi::CString, ptr};
+
+use ort_sys::{
+	ExecutionMode, GraphOptimizationLevel, ONNXTensorElementDataType, ONNXType, OrtAllocator, OrtAllocatorType, OrtApi, OrtArenaCfg, OrtCANNProviderOptions,
+	OrtCUDAProviderOptions, OrtCUDAProviderOptionsV2, OrtCustomCreateThreadFn, OrtCustomJoinThreadFn, OrtCustomOp, OrtCustomOpDomain, OrtDnnlProviderOptions,
+	OrtEnv, OrtErrorCode, OrtIoBinding, OrtKernelContext, OrtKernelInfo, OrtLanguageProjection, OrtLogger, OrtLoggingFunction, OrtLoggingLevel, OrtLoraAdapter,
+	OrtMIGraphXProviderOptions, OrtMapTypeInfo, OrtMemType, OrtMemoryInfo, OrtMemoryInfoDeviceType, OrtModelMetadata, OrtOp, OrtOpAttr, OrtOpAttrType,
+	OrtOpenVINOProviderOptions, OrtOptionalTypeInfo, OrtPrepackedWeightsContainer, OrtROCMProviderOptions, OrtRunOptions, OrtSequenceTypeInfo, OrtSession,
+	OrtSessionOptions, OrtShapeInferContext, OrtSparseFormat, OrtSparseIndicesFormat, OrtStatus, OrtStatusPtr, OrtTensorRTProviderOptions,
+	OrtTensorRTProviderOptionsV2, OrtTensorTypeAndShapeInfo, OrtThreadingOptions, OrtTrainingApi, OrtTypeInfo, OrtValue, RunAsyncCallbackFn, ortchar
+};
+
+use crate::{Environment, error::Error};
+
+unsafe extern "system" fn CreateStatus(code: OrtErrorCode, msg: *const ::std::os::raw::c_char) -> *mut OrtStatus {
+	let msg = CString::from_raw(msg.cast_mut());
+	Error::new_sys(code, msg.to_string_lossy())
+}
+
+unsafe extern "system" fn GetErrorCode(status: *const OrtStatus) -> OrtErrorCode {
+	Error::cast_from_sys(status).code
+}
+
+unsafe extern "system" fn GetErrorMessage(status: *const OrtStatus) -> *const ::std::os::raw::c_char {
+	Error::cast_from_sys(status).message_ptr()
+}
+
+unsafe extern "system" fn CreateEnv(log_severity_level: OrtLoggingLevel, logid: *const ::std::os::raw::c_char, out: *mut *mut OrtEnv) -> OrtStatusPtr {
+	*out = Environment::new_sys();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn CreateEnvWithCustomLogger(
+	logging_function: OrtLoggingFunction,
+	logger_param: *mut ::std::os::raw::c_void,
+	log_severity_level: OrtLoggingLevel,
+	logid: *const ::std::os::raw::c_char,
+	out: *mut *mut OrtEnv
+) -> OrtStatusPtr {
+	*out = Environment::new_sys();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn EnableTelemetryEvents(env: *const OrtEnv) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn DisableTelemetryEvents(env: *const OrtEnv) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateSession(
+	env: *const OrtEnv,
+	model_path: *const ortchar,
+	options: *const OrtSessionOptions,
+	out: *mut *mut OrtSession
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateSessionFromArray(
+	env: *const OrtEnv,
+	model_data: *const ::std::os::raw::c_void,
+	model_data_length: usize,
+	options: *const OrtSessionOptions,
+	out: *mut *mut OrtSession
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn Run(
+	session: *mut OrtSession,
+	run_options: *const OrtRunOptions,
+	input_names: *const *const ::std::os::raw::c_char,
+	inputs: *const *const OrtValue,
+	input_len: usize,
+	output_names: *const *const ::std::os::raw::c_char,
+	output_names_len: usize,
+	outputs: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateSessionOptions(options: *mut *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetOptimizedModelFilePath(options: *mut OrtSessionOptions, optimized_model_filepath: *const ortchar) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CloneSessionOptions(in_options: *const OrtSessionOptions, out_options: *mut *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetSessionExecutionMode(options: *mut OrtSessionOptions, execution_mode: ExecutionMode) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn EnableProfiling(options: *mut OrtSessionOptions, profile_file_prefix: *const ortchar) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn DisableProfiling(options: *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn EnableMemPattern(options: *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn DisableMemPattern(options: *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn EnableCpuMemArena(options: *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn DisableCpuMemArena(options: *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetSessionLogId(options: *mut OrtSessionOptions, logid: *const ::std::os::raw::c_char) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetSessionLogVerbosityLevel(options: *mut OrtSessionOptions, session_log_verbosity_level: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetSessionLogSeverityLevel(options: *mut OrtSessionOptions, session_log_severity_level: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetSessionGraphOptimizationLevel(options: *mut OrtSessionOptions, graph_optimization_level: GraphOptimizationLevel) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetIntraOpNumThreads(options: *mut OrtSessionOptions, intra_op_num_threads: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetInterOpNumThreads(options: *mut OrtSessionOptions, inter_op_num_threads: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateCustomOpDomain(domain: *const ::std::os::raw::c_char, out: *mut *mut OrtCustomOpDomain) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CustomOpDomain_Add(custom_op_domain: *mut OrtCustomOpDomain, op: *const OrtCustomOp) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddCustomOpDomain(options: *mut OrtSessionOptions, custom_op_domain: *mut OrtCustomOpDomain) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RegisterCustomOpsLibrary(
+	options: *mut OrtSessionOptions,
+	library_path: *const ::std::os::raw::c_char,
+	library_handle: *mut *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetInputCount(session: *const OrtSession, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetOutputCount(session: *const OrtSession, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetOverridableInitializerCount(session: *const OrtSession, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetInputTypeInfo(session: *const OrtSession, index: usize, type_info: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetOutputTypeInfo(session: *const OrtSession, index: usize, type_info: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetOverridableInitializerTypeInfo(session: *const OrtSession, index: usize, type_info: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetInputName(
+	session: *const OrtSession,
+	index: usize,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetOutputName(
+	session: *const OrtSession,
+	index: usize,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetOverridableInitializerName(
+	session: *const OrtSession,
+	index: usize,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateRunOptions(out: *mut *mut OrtRunOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsSetRunLogVerbosityLevel(options: *mut OrtRunOptions, log_verbosity_level: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsSetRunLogSeverityLevel(options: *mut OrtRunOptions, log_severity_level: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsSetRunTag(options: *mut OrtRunOptions, run_tag: *const ::std::os::raw::c_char) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsGetRunLogVerbosityLevel(options: *const OrtRunOptions, log_verbosity_level: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsGetRunLogSeverityLevel(options: *const OrtRunOptions, log_severity_level: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsGetRunTag(options: *const OrtRunOptions, run_tag: *mut *const ::std::os::raw::c_char) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsSetTerminate(options: *mut OrtRunOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsUnsetTerminate(options: *mut OrtRunOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateTensorAsOrtValue(
+	allocator: *mut OrtAllocator,
+	shape: *const i64,
+	shape_len: usize,
+	type_: ONNXTensorElementDataType,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateTensorWithDataAsOrtValue(
+	info: *const OrtMemoryInfo,
+	p_data: *mut ::std::os::raw::c_void,
+	p_data_len: usize,
+	shape: *const i64,
+	shape_len: usize,
+	type_: ONNXTensorElementDataType,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn IsTensor(value: *const OrtValue, out: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetTensorMutableData(value: *mut OrtValue, out: *mut *mut ::std::os::raw::c_void) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn FillStringTensor(value: *mut OrtValue, s: *const *const ::std::os::raw::c_char, s_len: usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetStringTensorDataLength(value: *const OrtValue, len: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetStringTensorContent(
+	value: *const OrtValue,
+	s: *mut ::std::os::raw::c_void,
+	s_len: usize,
+	offsets: *mut usize,
+	offsets_len: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CastTypeInfoToTensorInfo(type_info: *const OrtTypeInfo, out: *mut *const OrtTensorTypeAndShapeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetOnnxTypeFromTypeInfo(type_info: *const OrtTypeInfo, out: *mut ONNXType) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateTensorTypeAndShapeInfo(out: *mut *mut OrtTensorTypeAndShapeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetTensorElementType(info: *mut OrtTensorTypeAndShapeInfo, type_: ONNXTensorElementDataType) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetDimensions(info: *mut OrtTensorTypeAndShapeInfo, dim_values: *const i64, dim_count: usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetTensorElementType(info: *const OrtTensorTypeAndShapeInfo, out: *mut ONNXTensorElementDataType) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetDimensionsCount(info: *const OrtTensorTypeAndShapeInfo, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetDimensions(info: *const OrtTensorTypeAndShapeInfo, dim_values: *mut i64, dim_values_length: usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSymbolicDimensions(
+	info: *const OrtTensorTypeAndShapeInfo,
+	dim_params: *mut *const ::std::os::raw::c_char,
+	dim_params_length: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetTensorShapeElementCount(info: *const OrtTensorTypeAndShapeInfo, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetTensorTypeAndShape(value: *const OrtValue, out: *mut *mut OrtTensorTypeAndShapeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetTypeInfo(value: *const OrtValue, out: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetValueType(value: *const OrtValue, out: *mut ONNXType) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateMemoryInfo(
+	name: *const ::std::os::raw::c_char,
+	type_: OrtAllocatorType,
+	id: ::std::os::raw::c_int,
+	mem_type: OrtMemType,
+	out: *mut *mut OrtMemoryInfo
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateCpuMemoryInfo(type_: OrtAllocatorType, mem_type: OrtMemType, out: *mut *mut OrtMemoryInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CompareMemoryInfo(info1: *const OrtMemoryInfo, info2: *const OrtMemoryInfo, out: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn MemoryInfoGetName(ptr: *const OrtMemoryInfo, out: *mut *const ::std::os::raw::c_char) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn MemoryInfoGetId(ptr: *const OrtMemoryInfo, out: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn MemoryInfoGetMemType(ptr: *const OrtMemoryInfo, out: *mut OrtMemType) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn MemoryInfoGetType(ptr: *const OrtMemoryInfo, out: *mut OrtAllocatorType) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AllocatorAlloc(ort_allocator: *mut OrtAllocator, size: usize, out: *mut *mut ::std::os::raw::c_void) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AllocatorFree(ort_allocator: *mut OrtAllocator, p: *mut ::std::os::raw::c_void) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AllocatorGetInfo(ort_allocator: *const OrtAllocator, out: *mut *const OrtMemoryInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetAllocatorWithDefaultOptions(out: *mut *mut OrtAllocator) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddFreeDimensionOverride(
+	options: *mut OrtSessionOptions,
+	dim_denotation: *const ::std::os::raw::c_char,
+	dim_value: i64
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetValue(
+	value: *const OrtValue,
+	index: ::std::os::raw::c_int,
+	allocator: *mut OrtAllocator,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetValueCount(value: *const OrtValue, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateValue(in_: *const *const OrtValue, num_values: usize, value_type: ONNXType, out: *mut *mut OrtValue) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateOpaqueValue(
+	domain_name: *const ::std::os::raw::c_char,
+	type_name: *const ::std::os::raw::c_char,
+	data_container: *const ::std::os::raw::c_void,
+	data_container_size: usize,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetOpaqueValue(
+	domain_name: *const ::std::os::raw::c_char,
+	type_name: *const ::std::os::raw::c_char,
+	in_: *const OrtValue,
+	data_container: *mut ::std::os::raw::c_void,
+	data_container_size: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetAttribute_float(info: *const OrtKernelInfo, name: *const ::std::os::raw::c_char, out: *mut f32) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetAttribute_int64(info: *const OrtKernelInfo, name: *const ::std::os::raw::c_char, out: *mut i64) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetAttribute_string(
+	info: *const OrtKernelInfo,
+	name: *const ::std::os::raw::c_char,
+	out: *mut ::std::os::raw::c_char,
+	size: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetInputCount(context: *const OrtKernelContext, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetOutputCount(context: *const OrtKernelContext, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetInput(context: *const OrtKernelContext, index: usize, out: *mut *const OrtValue) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetOutput(
+	context: *mut OrtKernelContext,
+	index: usize,
+	dim_values: *const i64,
+	dim_count: usize,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseEnv(input: *mut OrtEnv) {
+	drop(Environment::consume_sys(input));
+}
+
+unsafe extern "system" fn ReleaseStatus(input: *mut OrtStatus) {
+	drop(Error::consume_sys(input));
+}
+
+unsafe extern "system" fn ReleaseMemoryInfo(input: *mut OrtMemoryInfo) {}
+
+unsafe extern "system" fn ReleaseSession(input: *mut OrtSession) {}
+
+unsafe extern "system" fn ReleaseValue(input: *mut OrtValue) {}
+
+unsafe extern "system" fn ReleaseRunOptions(input: *mut OrtRunOptions) {}
+
+unsafe extern "system" fn ReleaseTypeInfo(input: *mut OrtTypeInfo) {}
+
+unsafe extern "system" fn ReleaseTensorTypeAndShapeInfo(input: *mut OrtTensorTypeAndShapeInfo) {}
+
+unsafe extern "system" fn ReleaseSessionOptions(input: *mut OrtSessionOptions) {}
+
+unsafe extern "system" fn ReleaseCustomOpDomain(input: *mut OrtCustomOpDomain) {}
+
+unsafe extern "system" fn GetDenotationFromTypeInfo(
+	type_info: *const OrtTypeInfo,
+	denotation: *mut *const ::std::os::raw::c_char,
+	len: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CastTypeInfoToMapTypeInfo(type_info: *const OrtTypeInfo, out: *mut *const OrtMapTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CastTypeInfoToSequenceTypeInfo(type_info: *const OrtTypeInfo, out: *mut *const OrtSequenceTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetMapKeyType(map_type_info: *const OrtMapTypeInfo, out: *mut ONNXTensorElementDataType) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetMapValueType(map_type_info: *const OrtMapTypeInfo, type_info: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSequenceElementType(sequence_type_info: *const OrtSequenceTypeInfo, type_info: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseMapTypeInfo(input: *mut OrtMapTypeInfo) {}
+
+unsafe extern "system" fn ReleaseSequenceTypeInfo(input: *mut OrtSequenceTypeInfo) {}
+
+unsafe extern "system" fn SessionEndProfiling(session: *mut OrtSession, allocator: *mut OrtAllocator, out: *mut *mut ::std::os::raw::c_char) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetModelMetadata(session: *const OrtSession, out: *mut *mut OrtModelMetadata) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ModelMetadataGetProducerName(
+	model_metadata: *const OrtModelMetadata,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ModelMetadataGetGraphName(
+	model_metadata: *const OrtModelMetadata,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ModelMetadataGetDomain(
+	model_metadata: *const OrtModelMetadata,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ModelMetadataGetDescription(
+	model_metadata: *const OrtModelMetadata,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ModelMetadataLookupCustomMetadataMap(
+	model_metadata: *const OrtModelMetadata,
+	allocator: *mut OrtAllocator,
+	key: *const ::std::os::raw::c_char,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ModelMetadataGetVersion(model_metadata: *const OrtModelMetadata, value: *mut i64) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseModelMetadata(input: *mut OrtModelMetadata) {}
+
+unsafe extern "system" fn CreateEnvWithGlobalThreadPools(
+	log_severity_level: OrtLoggingLevel,
+	logid: *const ::std::os::raw::c_char,
+	tp_options: *const OrtThreadingOptions,
+	out: *mut *mut OrtEnv
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn DisablePerSessionThreads(options: *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateThreadingOptions(out: *mut *mut OrtThreadingOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseThreadingOptions(input: *mut OrtThreadingOptions) {}
+
+unsafe extern "system" fn ModelMetadataGetCustomMetadataMapKeys(
+	model_metadata: *const OrtModelMetadata,
+	allocator: *mut OrtAllocator,
+	keys: *mut *mut *mut ::std::os::raw::c_char,
+	num_keys: *mut i64
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddFreeDimensionOverrideByName(
+	options: *mut OrtSessionOptions,
+	dim_name: *const ::std::os::raw::c_char,
+	dim_value: i64
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetAvailableProviders(out_ptr: *mut *mut *mut ::std::os::raw::c_char, provider_length: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseAvailableProviders(ptr: *mut *mut ::std::os::raw::c_char, providers_length: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetStringTensorElementLength(value: *const OrtValue, index: usize, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetStringTensorElement(value: *const OrtValue, s_len: usize, index: usize, s: *mut ::std::os::raw::c_void) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn FillStringTensorElement(value: *mut OrtValue, s: *const ::std::os::raw::c_char, index: usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddSessionConfigEntry(
+	options: *mut OrtSessionOptions,
+	config_key: *const ::std::os::raw::c_char,
+	config_value: *const ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateAllocator(session: *const OrtSession, mem_info: *const OrtMemoryInfo, out: *mut *mut OrtAllocator) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseAllocator(input: *mut OrtAllocator) {}
+
+unsafe extern "system" fn RunWithBinding(session: *mut OrtSession, run_options: *const OrtRunOptions, binding_ptr: *const OrtIoBinding) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateIoBinding(session: *mut OrtSession, out: *mut *mut OrtIoBinding) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseIoBinding(input: *mut OrtIoBinding) {}
+
+unsafe extern "system" fn BindInput(binding_ptr: *mut OrtIoBinding, name: *const ::std::os::raw::c_char, val_ptr: *const OrtValue) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn BindOutput(binding_ptr: *mut OrtIoBinding, name: *const ::std::os::raw::c_char, val_ptr: *const OrtValue) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn BindOutputToDevice(
+	binding_ptr: *mut OrtIoBinding,
+	name: *const ::std::os::raw::c_char,
+	mem_info_ptr: *const OrtMemoryInfo
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetBoundOutputNames(
+	binding_ptr: *const OrtIoBinding,
+	allocator: *mut OrtAllocator,
+	buffer: *mut *mut ::std::os::raw::c_char,
+	lengths: *mut *mut usize,
+	count: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetBoundOutputValues(
+	binding_ptr: *const OrtIoBinding,
+	allocator: *mut OrtAllocator,
+	output: *mut *mut *mut OrtValue,
+	output_count: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ClearBoundInputs(binding_ptr: *mut OrtIoBinding) {}
+
+unsafe extern "system" fn ClearBoundOutputs(binding_ptr: *mut OrtIoBinding) {}
+
+unsafe extern "system" fn TensorAt(
+	value: *mut OrtValue,
+	location_values: *const i64,
+	location_values_count: usize,
+	out: *mut *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateAndRegisterAllocator(env: *mut OrtEnv, mem_info: *const OrtMemoryInfo, arena_cfg: *const OrtArenaCfg) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetLanguageProjection(ort_env: *const OrtEnv, projection: OrtLanguageProjection) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetProfilingStartTimeNs(session: *const OrtSession, out: *mut u64) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalIntraOpNumThreads(tp_options: *mut OrtThreadingOptions, intra_op_num_threads: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalInterOpNumThreads(tp_options: *mut OrtThreadingOptions, inter_op_num_threads: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalSpinControl(tp_options: *mut OrtThreadingOptions, allow_spinning: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddInitializer(options: *mut OrtSessionOptions, name: *const ::std::os::raw::c_char, val: *const OrtValue) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateEnvWithCustomLoggerAndGlobalThreadPools(
+	logging_function: OrtLoggingFunction,
+	logger_param: *mut ::std::os::raw::c_void,
+	log_severity_level: OrtLoggingLevel,
+	logid: *const ::std::os::raw::c_char,
+	tp_options: *const OrtThreadingOptions,
+	out: *mut *mut OrtEnv
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_CUDA(
+	options: *mut OrtSessionOptions,
+	cuda_options: *const OrtCUDAProviderOptions
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_ROCM(
+	options: *mut OrtSessionOptions,
+	rocm_options: *const OrtROCMProviderOptions
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_OpenVINO(
+	options: *mut OrtSessionOptions,
+	provider_options: *const OrtOpenVINOProviderOptions
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalDenormalAsZero(tp_options: *mut OrtThreadingOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateArenaCfg(
+	max_mem: usize,
+	arena_extend_strategy: ::std::os::raw::c_int,
+	initial_chunk_size_bytes: ::std::os::raw::c_int,
+	max_dead_bytes_per_chunk: ::std::os::raw::c_int,
+	out: *mut *mut OrtArenaCfg
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseArenaCfg(input: *mut OrtArenaCfg) {}
+
+unsafe extern "system" fn ModelMetadataGetGraphDescription(
+	model_metadata: *const OrtModelMetadata,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_TensorRT(
+	options: *mut OrtSessionOptions,
+	tensorrt_options: *const OrtTensorRTProviderOptions
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetCurrentGpuDeviceId(device_id: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetCurrentGpuDeviceId(device_id: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetAttributeArray_float(
+	info: *const OrtKernelInfo,
+	name: *const ::std::os::raw::c_char,
+	out: *mut f32,
+	size: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetAttributeArray_int64(
+	info: *const OrtKernelInfo,
+	name: *const ::std::os::raw::c_char,
+	out: *mut i64,
+	size: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateArenaCfgV2(
+	arena_config_keys: *const *const ::std::os::raw::c_char,
+	arena_config_values: *const usize,
+	num_keys: usize,
+	out: *mut *mut OrtArenaCfg
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddRunConfigEntry(
+	options: *mut OrtRunOptions,
+	config_key: *const ::std::os::raw::c_char,
+	config_value: *const ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreatePrepackedWeightsContainer(out: *mut *mut OrtPrepackedWeightsContainer) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleasePrepackedWeightsContainer(input: *mut OrtPrepackedWeightsContainer) {}
+
+unsafe extern "system" fn CreateSessionWithPrepackedWeightsContainer(
+	env: *const OrtEnv,
+	model_path: *const ortchar,
+	options: *const OrtSessionOptions,
+	prepacked_weights_container: *mut OrtPrepackedWeightsContainer,
+	out: *mut *mut OrtSession
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateSessionFromArrayWithPrepackedWeightsContainer(
+	env: *const OrtEnv,
+	model_data: *const ::std::os::raw::c_void,
+	model_data_length: usize,
+	options: *const OrtSessionOptions,
+	prepacked_weights_container: *mut OrtPrepackedWeightsContainer,
+	out: *mut *mut OrtSession
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_TensorRT_V2(
+	options: *mut OrtSessionOptions,
+	tensorrt_options: *const OrtTensorRTProviderOptionsV2
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateTensorRTProviderOptions(out: *mut *mut OrtTensorRTProviderOptionsV2) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UpdateTensorRTProviderOptions(
+	tensorrt_options: *mut OrtTensorRTProviderOptionsV2,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetTensorRTProviderOptionsAsString(
+	tensorrt_options: *const OrtTensorRTProviderOptionsV2,
+	allocator: *mut OrtAllocator,
+	ptr: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseTensorRTProviderOptions(input: *mut OrtTensorRTProviderOptionsV2) {}
+
+unsafe extern "system" fn EnableOrtCustomOps(options: *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RegisterAllocator(env: *mut OrtEnv, allocator: *mut OrtAllocator) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UnregisterAllocator(env: *mut OrtEnv, mem_info: *const OrtMemoryInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn IsSparseTensor(value: *const OrtValue, out: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateSparseTensorAsOrtValue(
+	allocator: *mut OrtAllocator,
+	dense_shape: *const i64,
+	dense_shape_len: usize,
+	type_: ONNXTensorElementDataType,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn FillSparseTensorCoo(
+	ort_value: *mut OrtValue,
+	data_mem_info: *const OrtMemoryInfo,
+	values_shape: *const i64,
+	values_shape_len: usize,
+	values: *const ::std::os::raw::c_void,
+	indices_data: *const i64,
+	indices_num: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn FillSparseTensorCsr(
+	ort_value: *mut OrtValue,
+	data_mem_info: *const OrtMemoryInfo,
+	values_shape: *const i64,
+	values_shape_len: usize,
+	values: *const ::std::os::raw::c_void,
+	inner_indices_data: *const i64,
+	inner_indices_num: usize,
+	outer_indices_data: *const i64,
+	outer_indices_num: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn FillSparseTensorBlockSparse(
+	ort_value: *mut OrtValue,
+	data_mem_info: *const OrtMemoryInfo,
+	values_shape: *const i64,
+	values_shape_len: usize,
+	values: *const ::std::os::raw::c_void,
+	indices_shape_data: *const i64,
+	indices_shape_len: usize,
+	indices_data: *const i32
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateSparseTensorWithValuesAsOrtValue(
+	info: *const OrtMemoryInfo,
+	p_data: *mut ::std::os::raw::c_void,
+	dense_shape: *const i64,
+	dense_shape_len: usize,
+	values_shape: *const i64,
+	values_shape_len: usize,
+	type_: ONNXTensorElementDataType,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UseCooIndices(ort_value: *mut OrtValue, indices_data: *mut i64, indices_num: usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UseCsrIndices(
+	ort_value: *mut OrtValue,
+	inner_data: *mut i64,
+	inner_num: usize,
+	outer_data: *mut i64,
+	outer_num: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UseBlockSparseIndices(
+	ort_value: *mut OrtValue,
+	indices_shape: *const i64,
+	indices_shape_len: usize,
+	indices_data: *mut i32
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSparseTensorFormat(ort_value: *const OrtValue, out: *mut OrtSparseFormat) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSparseTensorValuesTypeAndShape(ort_value: *const OrtValue, out: *mut *mut OrtTensorTypeAndShapeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSparseTensorValues(ort_value: *const OrtValue, out: *mut *const ::std::os::raw::c_void) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSparseTensorIndicesTypeShape(
+	ort_value: *const OrtValue,
+	indices_format: OrtSparseIndicesFormat,
+	out: *mut *mut OrtTensorTypeAndShapeInfo
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSparseTensorIndices(
+	ort_value: *const OrtValue,
+	indices_format: OrtSparseIndicesFormat,
+	num_indices: *mut usize,
+	indices: *mut *const ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn HasValue(value: *const OrtValue, out: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetGPUComputeStream(context: *const OrtKernelContext, out: *mut *mut ::std::os::raw::c_void) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetTensorMemoryInfo(value: *const OrtValue, mem_info: *mut *const OrtMemoryInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetExecutionProviderApi(
+	provider_name: *const ::std::os::raw::c_char,
+	version: u32,
+	provider_api: *mut *const ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsSetCustomCreateThreadFn(
+	options: *mut OrtSessionOptions,
+	ort_custom_create_thread_fn: OrtCustomCreateThreadFn
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsSetCustomThreadCreationOptions(
+	options: *mut OrtSessionOptions,
+	ort_custom_thread_creation_options: *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsSetCustomJoinThreadFn(
+	options: *mut OrtSessionOptions,
+	ort_custom_join_thread_fn: OrtCustomJoinThreadFn
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalCustomCreateThreadFn(
+	tp_options: *mut OrtThreadingOptions,
+	ort_custom_create_thread_fn: OrtCustomCreateThreadFn
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalCustomThreadCreationOptions(
+	tp_options: *mut OrtThreadingOptions,
+	ort_custom_thread_creation_options: *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalCustomJoinThreadFn(tp_options: *mut OrtThreadingOptions, ort_custom_join_thread_fn: OrtCustomJoinThreadFn) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SynchronizeBoundInputs(binding_ptr: *mut OrtIoBinding) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SynchronizeBoundOutputs(binding_ptr: *mut OrtIoBinding) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_CUDA_V2(
+	options: *mut OrtSessionOptions,
+	cuda_options: *const OrtCUDAProviderOptionsV2
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateCUDAProviderOptions(out: *mut *mut OrtCUDAProviderOptionsV2) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UpdateCUDAProviderOptions(
+	cuda_options: *mut OrtCUDAProviderOptionsV2,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetCUDAProviderOptionsAsString(
+	cuda_options: *const OrtCUDAProviderOptionsV2,
+	allocator: *mut OrtAllocator,
+	ptr: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseCUDAProviderOptions(input: *mut OrtCUDAProviderOptionsV2) {}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_MIGraphX(
+	options: *mut OrtSessionOptions,
+	migraphx_options: *const OrtMIGraphXProviderOptions
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddExternalInitializers(
+	options: *mut OrtSessionOptions,
+	initializer_names: *const *const ::std::os::raw::c_char,
+	initializers: *const *const OrtValue,
+	initializers_num: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateOpAttr(
+	name: *const ::std::os::raw::c_char,
+	data: *const ::std::os::raw::c_void,
+	len: ::std::os::raw::c_int,
+	type_: OrtOpAttrType,
+	op_attr: *mut *mut OrtOpAttr
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseOpAttr(input: *mut OrtOpAttr) {}
+
+unsafe extern "system" fn CreateOp(
+	info: *const OrtKernelInfo,
+	op_name: *const ::std::os::raw::c_char,
+	domain: *const ::std::os::raw::c_char,
+	version: ::std::os::raw::c_int,
+	type_constraint_names: *mut *const ::std::os::raw::c_char,
+	type_constraint_values: *const ONNXTensorElementDataType,
+	type_constraint_count: ::std::os::raw::c_int,
+	attr_values: *const *const OrtOpAttr,
+	attr_count: ::std::os::raw::c_int,
+	input_count: ::std::os::raw::c_int,
+	output_count: ::std::os::raw::c_int,
+	ort_op: *mut *mut OrtOp
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn InvokeOp(
+	context: *const OrtKernelContext,
+	ort_op: *const OrtOp,
+	input_values: *const *const OrtValue,
+	input_count: ::std::os::raw::c_int,
+	output_values: *const *mut OrtValue,
+	output_count: ::std::os::raw::c_int
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseOp(input: *mut OrtOp) {}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider(
+	options: *mut OrtSessionOptions,
+	provider_name: *const ::std::os::raw::c_char,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CopyKernelInfo(info: *const OrtKernelInfo, info_copy: *mut *mut OrtKernelInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseKernelInfo(input: *mut OrtKernelInfo) {}
+
+unsafe extern "system" fn GetTrainingApi(version: u32) -> *const OrtTrainingApi {
+	ptr::null()
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_CANN(
+	options: *mut OrtSessionOptions,
+	cann_options: *const OrtCANNProviderOptions
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateCANNProviderOptions(out: *mut *mut OrtCANNProviderOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UpdateCANNProviderOptions(
+	cann_options: *mut OrtCANNProviderOptions,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetCANNProviderOptionsAsString(
+	cann_options: *const OrtCANNProviderOptions,
+	allocator: *mut OrtAllocator,
+	ptr: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseCANNProviderOptions(input: *mut OrtCANNProviderOptions) {}
+
+unsafe extern "system" fn MemoryInfoGetDeviceType(ptr: *const OrtMemoryInfo, out: *mut OrtMemoryInfoDeviceType) {}
+
+unsafe extern "system" fn UpdateEnvWithCustomLogLevel(ort_env: *mut OrtEnv, log_severity_level: OrtLoggingLevel) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalIntraOpThreadAffinity(tp_options: *mut OrtThreadingOptions, affinity_string: *const ::std::os::raw::c_char) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RegisterCustomOpsLibrary_V2(options: *mut OrtSessionOptions, library_name: *const ortchar) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RegisterCustomOpsUsingFunction(
+	options: *mut OrtSessionOptions,
+	registration_func_name: *const ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfo_GetInputCount(info: *const OrtKernelInfo, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfo_GetOutputCount(info: *const OrtKernelInfo, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfo_GetInputName(
+	info: *const OrtKernelInfo,
+	index: usize,
+	out: *mut ::std::os::raw::c_char,
+	size: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfo_GetOutputName(
+	info: *const OrtKernelInfo,
+	index: usize,
+	out: *mut ::std::os::raw::c_char,
+	size: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfo_GetInputTypeInfo(info: *const OrtKernelInfo, index: usize, type_info: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfo_GetOutputTypeInfo(info: *const OrtKernelInfo, index: usize, type_info: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetAttribute_tensor(
+	info: *const OrtKernelInfo,
+	name: *const ::std::os::raw::c_char,
+	allocator: *mut OrtAllocator,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn HasSessionConfigEntry(
+	options: *const OrtSessionOptions,
+	config_key: *const ::std::os::raw::c_char,
+	out: *mut ::std::os::raw::c_int
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSessionConfigEntry(
+	options: *const OrtSessionOptions,
+	config_key: *const ::std::os::raw::c_char,
+	config_value: *mut ::std::os::raw::c_char,
+	size: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_Dnnl(
+	options: *mut OrtSessionOptions,
+	dnnl_options: *const OrtDnnlProviderOptions
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateDnnlProviderOptions(out: *mut *mut OrtDnnlProviderOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UpdateDnnlProviderOptions(
+	dnnl_options: *mut OrtDnnlProviderOptions,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetDnnlProviderOptionsAsString(
+	dnnl_options: *const OrtDnnlProviderOptions,
+	allocator: *mut OrtAllocator,
+	ptr: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseDnnlProviderOptions(input: *mut OrtDnnlProviderOptions) {}
+
+unsafe extern "system" fn KernelInfo_GetNodeName(info: *const OrtKernelInfo, out: *mut ::std::os::raw::c_char, size: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfo_GetLogger(info: *const OrtKernelInfo, logger: *mut *const OrtLogger) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetLogger(context: *const OrtKernelContext, logger: *mut *const OrtLogger) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn Logger_LogMessage(
+	logger: *const OrtLogger,
+	log_severity_level: OrtLoggingLevel,
+	message: *const ::std::os::raw::c_char,
+	file_path: *const ortchar,
+	line_number: ::std::os::raw::c_int,
+	func_name: *const ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn Logger_GetLoggingSeverityLevel(logger: *const OrtLogger, out: *mut OrtLoggingLevel) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetConstantInput_tensor(
+	info: *const OrtKernelInfo,
+	index: usize,
+	is_constant: *mut ::std::os::raw::c_int,
+	out: *mut *const OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CastTypeInfoToOptionalTypeInfo(type_info: *const OrtTypeInfo, out: *mut *const OrtOptionalTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetOptionalContainedTypeInfo(optional_type_info: *const OrtOptionalTypeInfo, out: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetResizedStringTensorElementBuffer(
+	value: *mut OrtValue,
+	index: usize,
+	length_in_bytes: usize,
+	buffer: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetAllocator(
+	context: *const OrtKernelContext,
+	mem_info: *const OrtMemoryInfo,
+	out: *mut *mut OrtAllocator
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetBuildInfoString() -> *const ::std::os::raw::c_char {
+	concat!("ORT Build Info: backend=ort-candle, version=", env!("CARGO_PKG_VERSION"), "\0")
+		.as_ptr()
+		.cast()
+}
+
+unsafe extern "system" fn CreateROCMProviderOptions(out: *mut *mut OrtROCMProviderOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UpdateROCMProviderOptions(
+	rocm_options: *mut OrtROCMProviderOptions,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetROCMProviderOptionsAsString(
+	rocm_options: *const OrtROCMProviderOptions,
+	allocator: *mut OrtAllocator,
+	ptr: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseROCMProviderOptions(input: *mut OrtROCMProviderOptions) {}
+
+unsafe extern "system" fn CreateAndRegisterAllocatorV2(
+	env: *mut OrtEnv,
+	provider_type: *const ::std::os::raw::c_char,
+	mem_info: *const OrtMemoryInfo,
+	arena_cfg: *const OrtArenaCfg,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunAsync(
+	session: *mut OrtSession,
+	run_options: *const OrtRunOptions,
+	input_names: *const *const ::std::os::raw::c_char,
+	input: *const *const OrtValue,
+	input_len: usize,
+	output_names: *const *const ::std::os::raw::c_char,
+	output_names_len: usize,
+	output: *mut *mut OrtValue,
+	run_async_callback: RunAsyncCallbackFn,
+	user_data: *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UpdateTensorRTProviderOptionsWithValue(
+	tensorrt_options: *mut OrtTensorRTProviderOptionsV2,
+	key: *const ::std::os::raw::c_char,
+	value: *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetTensorRTProviderOptionsByName(
+	tensorrt_options: *const OrtTensorRTProviderOptionsV2,
+	key: *const ::std::os::raw::c_char,
+	ptr: *mut *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UpdateCUDAProviderOptionsWithValue(
+	cuda_options: *mut OrtCUDAProviderOptionsV2,
+	key: *const ::std::os::raw::c_char,
+	value: *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetCUDAProviderOptionsByName(
+	cuda_options: *const OrtCUDAProviderOptionsV2,
+	key: *const ::std::os::raw::c_char,
+	ptr: *mut *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetResource(
+	context: *const OrtKernelContext,
+	resouce_version: ::std::os::raw::c_int,
+	resource_id: ::std::os::raw::c_int,
+	resource: *mut *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetUserLoggingFunction(
+	options: *mut OrtSessionOptions,
+	user_logging_function: OrtLoggingFunction,
+	user_logging_param: *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ShapeInferContext_GetInputCount(context: *const OrtShapeInferContext, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ShapeInferContext_GetInputTypeShape(
+	context: *const OrtShapeInferContext,
+	index: usize,
+	info: *mut *mut OrtTensorTypeAndShapeInfo
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ShapeInferContext_GetAttribute(
+	context: *const OrtShapeInferContext,
+	attr_name: *const ::std::os::raw::c_char,
+	attr: *mut *const OrtOpAttr
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ShapeInferContext_SetOutputTypeShape(
+	context: *const OrtShapeInferContext,
+	index: usize,
+	info: *const OrtTensorTypeAndShapeInfo
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetSymbolicDimensions(
+	info: *mut OrtTensorTypeAndShapeInfo,
+	dim_params: *mut *const ::std::os::raw::c_char,
+	dim_params_length: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReadOpAttr(
+	op_attr: *const OrtOpAttr,
+	type_: OrtOpAttrType,
+	data: *mut ::std::os::raw::c_void,
+	len: usize,
+	out: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetDeterministicCompute(options: *mut OrtSessionOptions, value: bool) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_ParallelFor(
+	context: *const OrtKernelContext,
+	fn_: unsafe extern "system" fn(arg1: *mut ::std::os::raw::c_void, arg2: usize),
+	total: usize,
+	num_batch: usize,
+	usr_data: *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_OpenVINO_V2(
+	options: *mut OrtSessionOptions,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_VitisAI(
+	options: *mut OrtSessionOptions,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetScratchBuffer(
+	context: *const OrtKernelContext,
+	mem_info: *const OrtMemoryInfo,
+	count_or_bytes: usize,
+	out: *mut *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetAllocator(info: *const OrtKernelInfo, mem_type: OrtMemType, out: *mut *mut OrtAllocator) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddExternalInitializersFromMemory(
+	options: *mut OrtSessionOptions,
+	external_initializer_file_names: *const *const ortchar,
+	external_initializer_file_buffer_array: *const *mut ::std::os::raw::c_char,
+	external_initializer_file_lengths: *const usize,
+	num_external_initializer_files: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateLoraAdapter(adapter_file_path: *const ortchar, allocator: *mut OrtAllocator, out: *mut *mut OrtLoraAdapter) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateLoraAdapterFromArray(
+	bytes: *const ::std::os::raw::c_void,
+	num_bytes: usize,
+	allocator: *mut OrtAllocator,
+	out: *mut *mut OrtLoraAdapter
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseLoraAdapter(input: *mut OrtLoraAdapter) {}
+
+unsafe extern "system" fn RunOptionsAddActiveLoraAdapter(options: *mut OrtRunOptions, adapter: *const OrtLoraAdapter) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetEpDynamicOptions(
+	sess: *mut OrtSession,
+	keys: *const *const ::std::os::raw::c_char,
+	values: *const *const ::std::os::raw::c_char,
+	kv_len: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+pub fn api() -> OrtApi {
+	OrtApi {
+		CreateStatus,
+		GetErrorCode,
+		GetErrorMessage,
+		CreateEnv,
+		CreateEnvWithCustomLogger,
+		EnableTelemetryEvents,
+		DisableTelemetryEvents,
+		CreateSession,
+		CreateSessionFromArray,
+		Run,
+		CreateSessionOptions,
+		SetOptimizedModelFilePath,
+		CloneSessionOptions,
+		SetSessionExecutionMode,
+		EnableProfiling,
+		DisableProfiling,
+		EnableMemPattern,
+		DisableMemPattern,
+		EnableCpuMemArena,
+		DisableCpuMemArena,
+		SetSessionLogId,
+		SetSessionLogVerbosityLevel,
+		SetSessionLogSeverityLevel,
+		SetSessionGraphOptimizationLevel,
+		SetIntraOpNumThreads,
+		SetInterOpNumThreads,
+		CreateCustomOpDomain,
+		CustomOpDomain_Add,
+		AddCustomOpDomain,
+		RegisterCustomOpsLibrary,
+		SessionGetInputCount,
+		SessionGetOutputCount,
+		SessionGetOverridableInitializerCount,
+		SessionGetInputTypeInfo,
+		SessionGetOutputTypeInfo,
+		SessionGetOverridableInitializerTypeInfo,
+		SessionGetInputName,
+		SessionGetOutputName,
+		SessionGetOverridableInitializerName,
+		CreateRunOptions,
+		RunOptionsSetRunLogVerbosityLevel,
+		RunOptionsSetRunLogSeverityLevel,
+		RunOptionsSetRunTag,
+		RunOptionsGetRunLogVerbosityLevel,
+		RunOptionsGetRunLogSeverityLevel,
+		RunOptionsGetRunTag,
+		RunOptionsSetTerminate,
+		RunOptionsUnsetTerminate,
+		CreateTensorAsOrtValue,
+		CreateTensorWithDataAsOrtValue,
+		IsTensor,
+		GetTensorMutableData,
+		FillStringTensor,
+		GetStringTensorDataLength,
+		GetStringTensorContent,
+		CastTypeInfoToTensorInfo,
+		GetOnnxTypeFromTypeInfo,
+		CreateTensorTypeAndShapeInfo,
+		SetTensorElementType,
+		SetDimensions,
+		GetTensorElementType,
+		GetDimensionsCount,
+		GetDimensions,
+		GetSymbolicDimensions,
+		GetTensorShapeElementCount,
+		GetTensorTypeAndShape,
+		GetTypeInfo,
+		GetValueType,
+		CreateMemoryInfo,
+		CreateCpuMemoryInfo,
+		CompareMemoryInfo,
+		MemoryInfoGetName,
+		MemoryInfoGetId,
+		MemoryInfoGetMemType,
+		MemoryInfoGetType,
+		AllocatorAlloc,
+		AllocatorFree,
+		AllocatorGetInfo,
+		GetAllocatorWithDefaultOptions,
+		AddFreeDimensionOverride,
+		GetValue,
+		GetValueCount,
+		CreateValue,
+		CreateOpaqueValue,
+		GetOpaqueValue,
+		KernelInfoGetAttribute_float,
+		KernelInfoGetAttribute_int64,
+		KernelInfoGetAttribute_string,
+		KernelContext_GetInputCount,
+		KernelContext_GetOutputCount,
+		KernelContext_GetInput,
+		KernelContext_GetOutput,
+		ReleaseEnv,
+		ReleaseStatus,
+		ReleaseMemoryInfo,
+		ReleaseSession,
+		ReleaseValue,
+		ReleaseRunOptions,
+		ReleaseTypeInfo,
+		ReleaseTensorTypeAndShapeInfo,
+		ReleaseSessionOptions,
+		ReleaseCustomOpDomain,
+		GetDenotationFromTypeInfo,
+		CastTypeInfoToMapTypeInfo,
+		CastTypeInfoToSequenceTypeInfo,
+		GetMapKeyType,
+		GetMapValueType,
+		GetSequenceElementType,
+		ReleaseMapTypeInfo,
+		ReleaseSequenceTypeInfo,
+		SessionEndProfiling,
+		SessionGetModelMetadata,
+		ModelMetadataGetProducerName,
+		ModelMetadataGetGraphName,
+		ModelMetadataGetDomain,
+		ModelMetadataGetDescription,
+		ModelMetadataLookupCustomMetadataMap,
+		ModelMetadataGetVersion,
+		ReleaseModelMetadata,
+		CreateEnvWithGlobalThreadPools,
+		DisablePerSessionThreads,
+		CreateThreadingOptions,
+		ReleaseThreadingOptions,
+		ModelMetadataGetCustomMetadataMapKeys,
+		AddFreeDimensionOverrideByName,
+		GetAvailableProviders,
+		ReleaseAvailableProviders,
+		GetStringTensorElementLength,
+		GetStringTensorElement,
+		FillStringTensorElement,
+		AddSessionConfigEntry,
+		CreateAllocator,
+		ReleaseAllocator,
+		RunWithBinding,
+		CreateIoBinding,
+		ReleaseIoBinding,
+		BindInput,
+		BindOutput,
+		BindOutputToDevice,
+		GetBoundOutputNames,
+		GetBoundOutputValues,
+		ClearBoundInputs,
+		ClearBoundOutputs,
+		TensorAt,
+		CreateAndRegisterAllocator,
+		SetLanguageProjection,
+		SessionGetProfilingStartTimeNs,
+		SetGlobalIntraOpNumThreads,
+		SetGlobalInterOpNumThreads,
+		SetGlobalSpinControl,
+		AddInitializer,
+		CreateEnvWithCustomLoggerAndGlobalThreadPools,
+		SessionOptionsAppendExecutionProvider_CUDA,
+		SessionOptionsAppendExecutionProvider_ROCM,
+		SessionOptionsAppendExecutionProvider_OpenVINO,
+		SetGlobalDenormalAsZero,
+		CreateArenaCfg,
+		ReleaseArenaCfg,
+		ModelMetadataGetGraphDescription,
+		SessionOptionsAppendExecutionProvider_TensorRT,
+		SetCurrentGpuDeviceId,
+		GetCurrentGpuDeviceId,
+		KernelInfoGetAttributeArray_float,
+		KernelInfoGetAttributeArray_int64,
+		CreateArenaCfgV2,
+		AddRunConfigEntry,
+		CreatePrepackedWeightsContainer,
+		ReleasePrepackedWeightsContainer,
+		CreateSessionWithPrepackedWeightsContainer,
+		CreateSessionFromArrayWithPrepackedWeightsContainer,
+		SessionOptionsAppendExecutionProvider_TensorRT_V2,
+		CreateTensorRTProviderOptions,
+		UpdateTensorRTProviderOptions,
+		GetTensorRTProviderOptionsAsString,
+		ReleaseTensorRTProviderOptions,
+		EnableOrtCustomOps,
+		RegisterAllocator,
+		UnregisterAllocator,
+		IsSparseTensor,
+		CreateSparseTensorAsOrtValue,
+		FillSparseTensorCoo,
+		FillSparseTensorCsr,
+		FillSparseTensorBlockSparse,
+		CreateSparseTensorWithValuesAsOrtValue,
+		UseCooIndices,
+		UseCsrIndices,
+		UseBlockSparseIndices,
+		GetSparseTensorFormat,
+		GetSparseTensorValuesTypeAndShape,
+		GetSparseTensorValues,
+		GetSparseTensorIndicesTypeShape,
+		GetSparseTensorIndices,
+		HasValue,
+		KernelContext_GetGPUComputeStream,
+		GetTensorMemoryInfo,
+		GetExecutionProviderApi,
+		SessionOptionsSetCustomCreateThreadFn,
+		SessionOptionsSetCustomThreadCreationOptions,
+		SessionOptionsSetCustomJoinThreadFn,
+		SetGlobalCustomCreateThreadFn,
+		SetGlobalCustomThreadCreationOptions,
+		SetGlobalCustomJoinThreadFn,
+		SynchronizeBoundInputs,
+		SynchronizeBoundOutputs,
+		SessionOptionsAppendExecutionProvider_CUDA_V2,
+		CreateCUDAProviderOptions,
+		UpdateCUDAProviderOptions,
+		GetCUDAProviderOptionsAsString,
+		ReleaseCUDAProviderOptions,
+		SessionOptionsAppendExecutionProvider_MIGraphX,
+		AddExternalInitializers,
+		CreateOpAttr,
+		ReleaseOpAttr,
+		CreateOp,
+		InvokeOp,
+		ReleaseOp,
+		SessionOptionsAppendExecutionProvider,
+		CopyKernelInfo,
+		ReleaseKernelInfo,
+		GetTrainingApi,
+		SessionOptionsAppendExecutionProvider_CANN,
+		CreateCANNProviderOptions,
+		UpdateCANNProviderOptions,
+		GetCANNProviderOptionsAsString,
+		ReleaseCANNProviderOptions,
+		MemoryInfoGetDeviceType,
+		UpdateEnvWithCustomLogLevel,
+		SetGlobalIntraOpThreadAffinity,
+		RegisterCustomOpsLibrary_V2,
+		RegisterCustomOpsUsingFunction,
+		KernelInfo_GetInputCount,
+		KernelInfo_GetOutputCount,
+		KernelInfo_GetInputName,
+		KernelInfo_GetOutputName,
+		KernelInfo_GetInputTypeInfo,
+		KernelInfo_GetOutputTypeInfo,
+		KernelInfoGetAttribute_tensor,
+		HasSessionConfigEntry,
+		GetSessionConfigEntry,
+		SessionOptionsAppendExecutionProvider_Dnnl,
+		CreateDnnlProviderOptions,
+		UpdateDnnlProviderOptions,
+		GetDnnlProviderOptionsAsString,
+		ReleaseDnnlProviderOptions,
+		KernelInfo_GetNodeName,
+		KernelInfo_GetLogger,
+		KernelContext_GetLogger,
+		Logger_LogMessage,
+		Logger_GetLoggingSeverityLevel,
+		KernelInfoGetConstantInput_tensor,
+		CastTypeInfoToOptionalTypeInfo,
+		GetOptionalContainedTypeInfo,
+		GetResizedStringTensorElementBuffer,
+		KernelContext_GetAllocator,
+		GetBuildInfoString,
+		CreateROCMProviderOptions,
+		UpdateROCMProviderOptions,
+		GetROCMProviderOptionsAsString,
+		ReleaseROCMProviderOptions,
+		CreateAndRegisterAllocatorV2,
+		RunAsync,
+		UpdateTensorRTProviderOptionsWithValue,
+		GetTensorRTProviderOptionsByName,
+		UpdateCUDAProviderOptionsWithValue,
+		GetCUDAProviderOptionsByName,
+		KernelContext_GetResource,
+		SetUserLoggingFunction,
+		ShapeInferContext_GetInputCount,
+		ShapeInferContext_GetInputTypeShape,
+		ShapeInferContext_GetAttribute,
+		ShapeInferContext_SetOutputTypeShape,
+		SetSymbolicDimensions,
+		ReadOpAttr,
+		SetDeterministicCompute,
+		KernelContext_ParallelFor,
+		SessionOptionsAppendExecutionProvider_OpenVINO_V2,
+		SessionOptionsAppendExecutionProvider_VitisAI,
+		KernelContext_GetScratchBuffer,
+		KernelInfoGetAllocator,
+		AddExternalInitializersFromMemory,
+		CreateLoraAdapter,
+		CreateLoraAdapterFromArray,
+		ReleaseLoraAdapter,
+		RunOptionsAddActiveLoraAdapter,
+		SetEpDynamicOptions
+	}
+}

--- a/backends/candle/api.rs
+++ b/backends/candle/api.rs
@@ -78,7 +78,7 @@ unsafe extern "system" fn CreateSession(
 		OsString::from_wide(path)
 	};
 	#[cfg(not(target_os = "windows"))]
-	let path = OsString::from_encoded_bytes_unchecked(path.to_vec());
+	let path = OsString::from_encoded_bytes_unchecked(path.iter().map(|c| *c as u8).collect::<Vec<_>>());
 
 	let buf = match fs::read(path) {
 		Ok(buf) => buf,

--- a/backends/candle/error.rs
+++ b/backends/candle/error.rs
@@ -1,0 +1,35 @@
+use std::ffi::{CString, c_char};
+
+#[derive(Debug, Clone)]
+pub struct Error {
+	pub code: ort_sys::OrtErrorCode,
+	message: CString
+}
+
+impl Error {
+	pub fn new_sys(code: ort_sys::OrtErrorCode, message: impl Into<String>) -> *mut ort_sys::OrtStatus {
+		(Box::leak(Box::new(Self {
+			code,
+			message: CString::new(message.into()).unwrap()
+		})) as *mut Error)
+			.cast()
+	}
+
+	#[inline]
+	pub fn message(&self) -> &str {
+		self.message.as_c_str().to_str().unwrap()
+	}
+
+	#[inline]
+	pub fn message_ptr(&self) -> *const c_char {
+		self.message.as_ptr()
+	}
+
+	pub unsafe fn cast_from_sys<'e>(ptr: *const ort_sys::OrtStatus) -> &'e Error {
+		unsafe { &*ptr.cast::<Error>() }
+	}
+
+	pub unsafe fn consume_sys(ptr: *mut ort_sys::OrtStatus) -> Box<Error> {
+		Box::from_raw(ptr.cast::<Error>())
+	}
+}

--- a/backends/candle/error.rs
+++ b/backends/candle/error.rs
@@ -7,12 +7,19 @@ pub struct Error {
 }
 
 impl Error {
-	pub fn new_sys(code: ort_sys::OrtErrorCode, message: impl Into<String>) -> *mut ort_sys::OrtStatus {
-		(Box::leak(Box::new(Self {
+	pub fn new(code: ort_sys::OrtErrorCode, message: impl Into<String>) -> Self {
+		Self {
 			code,
 			message: CString::new(message.into()).unwrap()
-		})) as *mut Error)
-			.cast()
+		}
+	}
+
+	pub fn into_sys(self) -> *mut ort_sys::OrtStatus {
+		(Box::leak(Box::new(self)) as *mut Error).cast()
+	}
+
+	pub fn new_sys(code: ort_sys::OrtErrorCode, message: impl Into<String>) -> *mut ort_sys::OrtStatus {
+		Self::new(code, message).into_sys()
 	}
 
 	#[inline]

--- a/backends/candle/lib.rs
+++ b/backends/candle/lib.rs
@@ -4,6 +4,7 @@ use ort_sys::OrtErrorCode;
 mod api;
 pub(crate) mod error;
 mod memory;
+mod session;
 mod tensor;
 
 pub use self::api::api;

--- a/backends/candle/lib.rs
+++ b/backends/candle/lib.rs
@@ -1,0 +1,20 @@
+mod api;
+pub(crate) mod error;
+
+pub(crate) struct Environment {}
+
+impl Environment {
+	pub fn new_sys() -> *mut ort_sys::OrtEnv {
+		(Box::leak(Box::new(Self {})) as *mut Environment).cast()
+	}
+
+	pub unsafe fn cast_from_sys<'e>(ptr: *const ort_sys::OrtEnv) -> &'e Environment {
+		unsafe { &*ptr.cast::<Environment>() }
+	}
+
+	pub unsafe fn consume_sys(ptr: *mut ort_sys::OrtEnv) -> Box<Environment> {
+		Box::from_raw(ptr.cast::<Environment>())
+	}
+}
+
+pub use self::api::api;

--- a/backends/candle/lib.rs
+++ b/backends/candle/lib.rs
@@ -1,5 +1,6 @@
 mod api;
 pub(crate) mod error;
+mod memory;
 
 pub(crate) struct Environment {}
 

--- a/backends/candle/lib.rs
+++ b/backends/candle/lib.rs
@@ -1,6 +1,12 @@
+use candle_core::DType;
+use ort_sys::OrtErrorCode;
+
 mod api;
 pub(crate) mod error;
 mod memory;
+
+pub use self::api::api;
+use self::error::Error;
 
 pub(crate) struct Environment {}
 
@@ -18,4 +24,27 @@ impl Environment {
 	}
 }
 
-pub use self::api::api;
+fn convert_sys_to_dtype(sys: ort_sys::ONNXTensorElementDataType) -> Result<DType, Error> {
+	match sys {
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8 => Ok(DType::U8),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32 => Ok(DType::U32),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64 => Ok(DType::I64),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16 => Ok(DType::BF16),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 => Ok(DType::F16),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT => Ok(DType::F32),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE => Ok(DType::F64),
+		_ => Err(Error::new(OrtErrorCode::ORT_FAIL, "Element type not supported by candle"))
+	}
+}
+
+fn convert_dtype_to_sys(dtype: DType) -> ort_sys::ONNXTensorElementDataType {
+	match dtype {
+		DType::U8 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8,
+		DType::U32 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32,
+		DType::I64 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64,
+		DType::BF16 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16,
+		DType::F16 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+		DType::F32 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT,
+		DType::F64 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE
+	}
+}

--- a/backends/candle/lib.rs
+++ b/backends/candle/lib.rs
@@ -4,6 +4,7 @@ use ort_sys::OrtErrorCode;
 mod api;
 pub(crate) mod error;
 mod memory;
+mod tensor;
 
 pub use self::api::api;
 use self::error::Error;

--- a/backends/candle/memory.rs
+++ b/backends/candle/memory.rs
@@ -1,4 +1,4 @@
-use std::ptr;
+use std::{any::Any, ffi::CString, ptr};
 
 use candle_core::{Device, DeviceLocation, backend::BackendDevice};
 use ort_sys::{OrtAllocatorType, OrtErrorCode, OrtMemType, OrtMemoryInfoDeviceType};
@@ -95,7 +95,9 @@ unsafe extern "system" fn sys_allocator_alloc(_this: *mut ort_sys::OrtAllocator,
 	ptr::null_mut()
 }
 
-unsafe extern "system" fn sys_allocator_free(_this: *mut ort_sys::OrtAllocator, _p: *mut ::std::os::raw::c_void) {}
+unsafe extern "system" fn sys_allocator_free(_this: *mut ort_sys::OrtAllocator, p: *mut ::std::os::raw::c_void) {
+	drop(CString::from_raw(p.cast()));
+}
 
 unsafe extern "system" fn sys_allocator_info(this_: *const ort_sys::OrtAllocator) -> *const ort_sys::OrtMemoryInfo {
 	let _allocator = unsafe { &*this_.cast::<Allocator>() };

--- a/backends/candle/memory.rs
+++ b/backends/candle/memory.rs
@@ -1,0 +1,102 @@
+use std::ptr;
+
+use candle_core::{Device, DeviceLocation, backend::BackendDevice};
+use ort_sys::{OrtAllocatorType, OrtErrorCode, OrtMemType, OrtMemoryInfoDeviceType};
+
+use crate::error::Error;
+
+pub struct MemoryInfo(Device);
+
+impl MemoryInfo {
+	pub fn new(device_name: impl AsRef<str>, device_id: usize, mem_type: OrtMemType) -> Result<Self, Error> {
+		match device_name.as_ref() {
+			"Cpu" | "CudaPinned" => Ok(Self(Device::Cpu)),
+			"Cuda" => match mem_type {
+				OrtMemType::OrtMemTypeCPUInput | OrtMemType::OrtMemTypeCPUOutput => Ok(Self(Device::Cpu)),
+				OrtMemType::OrtMemTypeDefault => Device::new_cuda(device_id)
+					.map(Self)
+					.map_err(|e| Error::new(OrtErrorCode::ORT_ENGINE_ERROR, e.to_string()))
+			},
+			"Metal" => Device::new_metal(device_id)
+				.map(Self)
+				.map_err(|e| Error::new(OrtErrorCode::ORT_ENGINE_ERROR, e.to_string())),
+			device_name => Err(Error::new(OrtErrorCode::ORT_NOT_IMPLEMENTED, format!("ort-candle does not support the '{device_name}' device")))
+		}
+	}
+
+	pub fn device_type(&self) -> OrtMemoryInfoDeviceType {
+		match &self.0 {
+			Device::Cpu => OrtMemoryInfoDeviceType::OrtMemoryInfoDeviceType_CPU,
+			Device::Cuda(_) | Device::Metal(_) => OrtMemoryInfoDeviceType::OrtMemoryInfoDeviceType_GPU
+		}
+	}
+
+	pub fn device_name(&self) -> &'static str {
+		let sys_str = self.device_name_sys();
+		&sys_str[..sys_str.len() - 1]
+	}
+
+	pub fn device_name_sys(&self) -> &'static str {
+		match &self.0 {
+			Device::Cpu => "Cpu\0",
+			Device::Cuda(_) => "Cuda\0",
+			Device::Metal(_) => "Metal\0"
+		}
+	}
+
+	pub fn device_id(&self) -> usize {
+		match self.0.location() {
+			DeviceLocation::Cpu => 0,
+			DeviceLocation::Cuda { gpu_id } => gpu_id,
+			DeviceLocation::Metal { gpu_id } => gpu_id
+		}
+	}
+
+	pub fn memory_type(&self) -> OrtMemType {
+		OrtMemType::OrtMemTypeDefault
+	}
+}
+
+impl PartialEq for MemoryInfo {
+	fn eq(&self, other: &Self) -> bool {
+		self.0.same_device(&other.0)
+	}
+}
+
+#[repr(C)]
+pub struct Allocator<'m> {
+	_sys_api: ort_sys::OrtAllocator,
+	pub memory_info: &'m MemoryInfo
+}
+
+impl<'m> Allocator<'m> {
+	pub const fn new(memory_info: &'m MemoryInfo) -> Self {
+		Self {
+			_sys_api: ort_sys::OrtAllocator {
+				version: ort_sys::ORT_API_VERSION,
+				Alloc: Some(sys_allocator_alloc),
+				Free: Some(sys_allocator_free),
+				Info: Some(sys_allocator_info),
+				Reserve: Some(sys_allocator_reserve)
+			},
+			memory_info
+		}
+	}
+}
+
+pub static DEFAULT_CPU_ALLOCATOR: Allocator = Allocator::new(&MemoryInfo(Device::Cpu));
+
+unsafe extern "system" fn sys_allocator_alloc(_this: *mut ort_sys::OrtAllocator, _size: usize) -> *mut ::std::os::raw::c_void {
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn sys_allocator_free(_this: *mut ort_sys::OrtAllocator, _p: *mut ::std::os::raw::c_void) {}
+
+unsafe extern "system" fn sys_allocator_info(this_: *const ort_sys::OrtAllocator) -> *const ort_sys::OrtMemoryInfo {
+	let _allocator = unsafe { &*this_.cast::<Allocator>() };
+	(_allocator.memory_info as *const MemoryInfo).cast()
+}
+
+unsafe extern "system" fn sys_allocator_reserve(_this: *const ort_sys::OrtAllocator, _size: usize) -> *mut ::std::os::raw::c_void {
+	ptr::null_mut()
+}

--- a/backends/candle/memory.rs
+++ b/backends/candle/memory.rs
@@ -5,7 +5,8 @@ use ort_sys::{OrtAllocatorType, OrtErrorCode, OrtMemType, OrtMemoryInfoDeviceTyp
 
 use crate::error::Error;
 
-pub struct MemoryInfo(Device);
+#[repr(transparent)]
+pub struct MemoryInfo(pub Device);
 
 impl MemoryInfo {
 	pub fn new(device_name: impl AsRef<str>, device_id: usize, mem_type: OrtMemType) -> Result<Self, Error> {
@@ -22,6 +23,10 @@ impl MemoryInfo {
 				.map_err(|e| Error::new(OrtErrorCode::ORT_ENGINE_ERROR, e.to_string())),
 			device_name => Err(Error::new(OrtErrorCode::ORT_NOT_IMPLEMENTED, format!("ort-candle does not support the '{device_name}' device")))
 		}
+	}
+
+	pub fn device(&self) -> &Device {
+		&self.0
 	}
 
 	pub fn device_type(&self) -> OrtMemoryInfoDeviceType {

--- a/backends/candle/session.rs
+++ b/backends/candle/session.rs
@@ -1,0 +1,23 @@
+use std::{collections::HashMap, path::Path};
+
+use candle_core::Tensor;
+use candle_onnx::onnx::ModelProto;
+use prost::Message;
+
+#[derive(Default, Clone)]
+pub struct SessionOptions;
+
+pub struct Session {
+	pub model: ModelProto
+}
+
+impl Session {
+	pub fn from_buffer(_options: &SessionOptions, data: &[u8]) -> Result<Session, prost::DecodeError> {
+		let model = ModelProto::decode(data)?;
+		Ok(Session { model })
+	}
+
+	pub fn run(&self, inputs: HashMap<String, Tensor>) -> candle_core::Result<HashMap<String, Tensor>> {
+		candle_onnx::simple_eval(&self.model, inputs)
+	}
+}

--- a/backends/candle/tensor.rs
+++ b/backends/candle/tensor.rs
@@ -1,12 +1,12 @@
-use candle_core::{DType, Shape};
+use candle_core::DType;
 
 pub struct TypeInfo {
 	pub dtype: DType,
-	pub shape: Shape
+	pub shape: Vec<i64>
 }
 
 impl TypeInfo {
-	pub fn new_sys(dtype: DType, shape: Shape) -> *mut ort_sys::OrtTypeInfo {
+	pub fn new_sys(dtype: DType, shape: Vec<i64>) -> *mut ort_sys::OrtTypeInfo {
 		(Box::leak(Box::new(Self { dtype, shape })) as *mut TypeInfo).cast()
 	}
 

--- a/backends/candle/tensor.rs
+++ b/backends/candle/tensor.rs
@@ -1,0 +1,16 @@
+use candle_core::{DType, Shape};
+
+pub struct TypeInfo {
+	pub dtype: DType,
+	pub shape: Shape
+}
+
+impl TypeInfo {
+	pub fn new_sys(dtype: DType, shape: Shape) -> *mut ort_sys::OrtTypeInfo {
+		(Box::leak(Box::new(Self { dtype, shape })) as *mut TypeInfo).cast()
+	}
+
+	pub unsafe fn consume_sys(ptr: *mut ort_sys::OrtTypeInfo) -> Box<TypeInfo> {
+		Box::from_raw(ptr.cast::<TypeInfo>())
+	}
+}

--- a/backends/candle/tests/memory.rs
+++ b/backends/candle/tests/memory.rs
@@ -1,0 +1,16 @@
+use ort::memory::{AllocationDevice, Allocator, DeviceType};
+
+#[test]
+fn test_memory_info_apis() {
+	ort::set_api(ort_candle::api());
+
+	let allocator = Allocator::default();
+
+	let memory_info = allocator.memory_info();
+	assert_eq!(memory_info.allocation_device(), AllocationDevice::CPU);
+	assert_eq!(memory_info.device_type(), DeviceType::CPU);
+	assert_eq!(memory_info.device_id(), 0);
+
+	let memory_info_clone = memory_info.clone();
+	assert_eq!(memory_info, memory_info_clone);
+}

--- a/backends/candle/tests/tensor.rs
+++ b/backends/candle/tests/tensor.rs
@@ -1,0 +1,17 @@
+use ort::value::Tensor;
+
+#[test]
+fn test_tensors() -> ort::Result<()> {
+	ort::set_api(ort_candle::api());
+
+	let mut tensor = Tensor::<i64>::from_array((vec![5], vec![0, 1, 2, 3, 4]))?;
+	let ptr = tensor.data_ptr_mut()?.cast::<i64>();
+	unsafe {
+		*ptr.add(3) = 42;
+	};
+
+	let (_, extracted) = tensor.extract_raw_tensor();
+	assert_eq!(&extracted, &[0, 1, 2, 42, 4]);
+
+	Ok(())
+}

--- a/backends/tract/Cargo.toml
+++ b/backends/tract/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "ort-tract"
+description = "ort + tract = 🦀 - An alternative backend for ort, powered by tract."
+version = "0.1.0+0.8.1"
+edition = "2021"
+rust-version = "1.70"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/pykeio/ort"
+homepage = "https://ort.pyke.io/"
+keywords = [ "machine-learning", "ai", "ml" , "sys"]
+categories = [ "algorithms", "mathematics", "science" ]
+authors = [
+	"pyke.io <contact@pyke.io>"
+]
+
+[lib]
+name = "ort_tract"
+path = "lib.rs"
+
+[features]
+
+[dependencies]
+ort-sys = { version = "=2.0.0-rc.9", path = "../../ort-sys", default-features = false }
+tract-onnx = "0.21"
+parking_lot = "0.12"
+
+[dev-dependencies]
+ort = { version = "=2.0.0-rc.9", path = "../../", default-features = false, features = [ "alternative-backend", "fetch-models" ] }
+
+[[test]]
+name = "memory"
+path = "tests/memory.rs"
+[[test]]
+name = "tensor"
+path = "tests/tensor.rs"

--- a/backends/tract/Cargo.toml
+++ b/backends/tract/Cargo.toml
@@ -25,7 +25,10 @@ tract-onnx = "0.21"
 parking_lot = "0.12"
 
 [dev-dependencies]
-ort = { version = "=2.0.0-rc.9", path = "../../", default-features = false, features = [ "alternative-backend", "fetch-models" ] }
+ort = { version = "=2.0.0-rc.9", path = "../../", default-features = false, features = [ "alternative-backend", "fetch-models", "ndarray" ] }
+ureq = "2.1"
+image = "0.25"
+ndarray = "0.16"
 
 [[test]]
 name = "memory"
@@ -33,3 +36,6 @@ path = "tests/memory.rs"
 [[test]]
 name = "tensor"
 path = "tests/tensor.rs"
+[[test]]
+name = "session"
+path = "tests/session.rs"

--- a/backends/tract/api.rs
+++ b/backends/tract/api.rs
@@ -1,0 +1,2195 @@
+#![allow(non_snake_case, unused)]
+
+use std::{
+	collections::HashMap,
+	ffi::{CStr, CString, OsStr, OsString},
+	fs, mem, ptr
+};
+
+use ort_sys::{
+	ExecutionMode, GraphOptimizationLevel, ONNXTensorElementDataType, ONNXType, OrtAllocator, OrtAllocatorType, OrtApi, OrtArenaCfg, OrtCANNProviderOptions,
+	OrtCUDAProviderOptions, OrtCUDAProviderOptionsV2, OrtCustomCreateThreadFn, OrtCustomJoinThreadFn, OrtCustomOp, OrtCustomOpDomain, OrtDnnlProviderOptions,
+	OrtEnv, OrtErrorCode, OrtIoBinding, OrtKernelContext, OrtKernelInfo, OrtLanguageProjection, OrtLogger, OrtLoggingFunction, OrtLoggingLevel, OrtLoraAdapter,
+	OrtMIGraphXProviderOptions, OrtMapTypeInfo, OrtMemType, OrtMemoryInfo, OrtMemoryInfoDeviceType, OrtModelMetadata, OrtOp, OrtOpAttr, OrtOpAttrType,
+	OrtOpenVINOProviderOptions, OrtOptionalTypeInfo, OrtPrepackedWeightsContainer, OrtROCMProviderOptions, OrtRunOptions, OrtSequenceTypeInfo, OrtSession,
+	OrtSessionOptions, OrtShapeInferContext, OrtSparseFormat, OrtSparseIndicesFormat, OrtStatus, OrtStatusPtr, OrtTensorRTProviderOptions,
+	OrtTensorRTProviderOptionsV2, OrtTensorTypeAndShapeInfo, OrtThreadingOptions, OrtTrainingApi, OrtTypeInfo, OrtValue, RunAsyncCallbackFn, ortchar
+};
+use tract_onnx::prelude::*;
+
+use crate::{
+	Environment, convert_datum_type_to_sys, convert_sys_to_datum_type,
+	error::Error,
+	memory::Allocator,
+	session::{Session, SessionOptions},
+	tensor::TypeInfo
+};
+
+unsafe extern "system" fn CreateStatus(code: OrtErrorCode, msg: *const ::std::os::raw::c_char) -> *mut OrtStatus {
+	let msg = CString::from_raw(msg.cast_mut());
+	Error::new_sys(code, msg.to_string_lossy())
+}
+
+unsafe extern "system" fn GetErrorCode(status: *const OrtStatus) -> OrtErrorCode {
+	Error::cast_from_sys(status).code
+}
+
+unsafe extern "system" fn GetErrorMessage(status: *const OrtStatus) -> *const ::std::os::raw::c_char {
+	Error::cast_from_sys(status).message_ptr()
+}
+
+unsafe extern "system" fn CreateEnv(log_severity_level: OrtLoggingLevel, logid: *const ::std::os::raw::c_char, out: *mut *mut OrtEnv) -> OrtStatusPtr {
+	*out = Environment::new_sys();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn CreateEnvWithCustomLogger(
+	logging_function: OrtLoggingFunction,
+	logger_param: *mut ::std::os::raw::c_void,
+	log_severity_level: OrtLoggingLevel,
+	logid: *const ::std::os::raw::c_char,
+	out: *mut *mut OrtEnv
+) -> OrtStatusPtr {
+	*out = Environment::new_sys();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn EnableTelemetryEvents(env: *const OrtEnv) -> OrtStatusPtr {
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn DisableTelemetryEvents(env: *const OrtEnv) -> OrtStatusPtr {
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn CreateSession(
+	env: *const OrtEnv,
+	model_path: *const ortchar,
+	options: *const OrtSessionOptions,
+	out: *mut *mut OrtSession
+) -> OrtStatusPtr {
+	let env = unsafe { &*env.cast::<Environment>() };
+	let options = unsafe { &*options.cast::<SessionOptions>() };
+
+	let len = (0..).take_while(|&i| *model_path.offset(i) != 0).count();
+	let path = std::slice::from_raw_parts(model_path, len);
+	#[cfg(target_os = "windows")]
+	let path = {
+		use std::os::windows::ffi::OsStringExt;
+		OsString::from_wide(path)
+	};
+	#[cfg(not(target_os = "windows"))]
+	let path = OsString::from_encoded_bytes_unchecked(path.to_vec());
+
+	let buf = match fs::read(path) {
+		Ok(buf) => buf,
+		Err(e) => return Error::new_sys(OrtErrorCode::ORT_NO_SUCHFILE, format!("Failed to read model file: {e}"))
+	};
+
+	match Session::from_buffer(env, options, &buf) {
+		Ok(session) => {
+			*out = (Box::leak(Box::new(session)) as *mut Session).cast();
+			ptr::null_mut()
+		}
+		Err(e) => Error::new_sys(OrtErrorCode::ORT_FAIL, format!("Failed to parse model: {e}"))
+	}
+}
+
+unsafe extern "system" fn CreateSessionFromArray(
+	env: *const OrtEnv,
+	model_data: *const ::std::os::raw::c_void,
+	model_data_length: usize,
+	options: *const OrtSessionOptions,
+	out: *mut *mut OrtSession
+) -> OrtStatusPtr {
+	let env = unsafe { &*env.cast::<Environment>() };
+	let options = unsafe { &*options.cast::<SessionOptions>() };
+
+	let buf = std::slice::from_raw_parts(model_data.cast::<u8>(), model_data_length);
+
+	match Session::from_buffer(env, options, buf) {
+		Ok(session) => {
+			*out = (Box::leak(Box::new(session)) as *mut Session).cast();
+			ptr::null_mut()
+		}
+		Err(e) => Error::new_sys(OrtErrorCode::ORT_FAIL, format!("Failed to parse model: {e}"))
+	}
+}
+
+unsafe extern "system" fn Run(
+	session: *mut OrtSession,
+	run_options: *const OrtRunOptions,
+	input_names: *const *const ::std::os::raw::c_char,
+	inputs: *const *const OrtValue,
+	input_len: usize,
+	output_names: *const *const ::std::os::raw::c_char,
+	output_names_len: usize,
+	output_ptrs: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	let session = unsafe { &*session.cast::<Session>() };
+
+	let inputs: HashMap<String, Tensor> = std::slice::from_raw_parts(input_names, input_len)
+		.iter()
+		.zip(std::slice::from_raw_parts(inputs, input_len))
+		.map(|(&name, &input)| {
+			let name = unsafe { CStr::from_ptr(name) };
+			let input = unsafe { &*input.cast::<Tensor>() };
+			(name.to_string_lossy().to_string(), input.clone())
+		})
+		.collect();
+
+	match session.run(inputs) {
+		Ok(outputs) => {
+			let output_names: Vec<String> = std::slice::from_raw_parts(input_names, input_len)
+				.iter()
+				.map(|&name| unsafe { CStr::from_ptr(name) }.to_string_lossy().to_string())
+				.collect();
+			let output_view = std::slice::from_raw_parts_mut(output_ptrs, output_names_len);
+
+			for (name, tensor) in outputs {
+				if let Some(index) = output_names
+					.iter()
+					.zip(output_view.iter())
+					.find_map(|(o_name, output)| if name == *o_name { Some(*output) } else { None })
+				{
+					*index.cast::<Tensor>() = tensor;
+				}
+			}
+
+			ptr::null_mut()
+		}
+		Err(e) => Error::new_sys(OrtErrorCode::ORT_FAIL, format!("Failed to run session: {e}"))
+	}
+}
+
+unsafe extern "system" fn CreateSessionOptions(options: *mut *mut OrtSessionOptions) -> OrtStatusPtr {
+	*options = (Box::leak(Box::new(SessionOptions::default())) as *mut SessionOptions).cast();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn SetOptimizedModelFilePath(options: *mut OrtSessionOptions, optimized_model_filepath: *const ortchar) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CloneSessionOptions(in_options: *const OrtSessionOptions, out_options: *mut *mut OrtSessionOptions) -> OrtStatusPtr {
+	let options = unsafe { &*in_options.cast::<SessionOptions>() };
+	*out_options = (Box::leak(Box::new(options.clone())) as *mut SessionOptions).cast();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn SetSessionExecutionMode(options: *mut OrtSessionOptions, execution_mode: ExecutionMode) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn EnableProfiling(options: *mut OrtSessionOptions, profile_file_prefix: *const ortchar) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn DisableProfiling(options: *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn EnableMemPattern(options: *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn DisableMemPattern(options: *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn EnableCpuMemArena(options: *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn DisableCpuMemArena(options: *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetSessionLogId(options: *mut OrtSessionOptions, logid: *const ::std::os::raw::c_char) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetSessionLogVerbosityLevel(options: *mut OrtSessionOptions, session_log_verbosity_level: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetSessionLogSeverityLevel(options: *mut OrtSessionOptions, session_log_severity_level: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetSessionGraphOptimizationLevel(options: *mut OrtSessionOptions, graph_optimization_level: GraphOptimizationLevel) -> OrtStatusPtr {
+	let options = unsafe { &mut *options.cast::<SessionOptions>() };
+	if graph_optimization_level != GraphOptimizationLevel::ORT_DISABLE_ALL {
+		options.perform_optimizations = true;
+	} else {
+		options.perform_optimizations = false;
+	}
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn SetIntraOpNumThreads(options: *mut OrtSessionOptions, intra_op_num_threads: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetInterOpNumThreads(options: *mut OrtSessionOptions, inter_op_num_threads: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateCustomOpDomain(domain: *const ::std::os::raw::c_char, out: *mut *mut OrtCustomOpDomain) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CustomOpDomain_Add(custom_op_domain: *mut OrtCustomOpDomain, op: *const OrtCustomOp) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddCustomOpDomain(options: *mut OrtSessionOptions, custom_op_domain: *mut OrtCustomOpDomain) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RegisterCustomOpsLibrary(
+	options: *mut OrtSessionOptions,
+	library_path: *const ::std::os::raw::c_char,
+	library_handle: *mut *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetInputCount(session: *const OrtSession, out: *mut usize) -> OrtStatusPtr {
+	let session = unsafe { &*session.cast::<Session>() };
+	*out = session.original_graph.inputs.len();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn SessionGetOutputCount(session: *const OrtSession, out: *mut usize) -> OrtStatusPtr {
+	let session = unsafe { &*session.cast::<Session>() };
+	*out = session.original_graph.outputs.len();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn SessionGetOverridableInitializerCount(session: *const OrtSession, out: *mut usize) -> OrtStatusPtr {
+	*out = 0;
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn SessionGetInputTypeInfo(session: *const OrtSession, index: usize, type_info: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	let session = unsafe { &*session.cast::<Session>() };
+	let (fact, label) = match session.original_graph.input_fact(index) {
+		Ok(fact) => (fact, session.outlet_labels.get(&session.original_graph.inputs[index]).unwrap()),
+		Err(e) => return Error::new_sys(OrtErrorCode::ORT_FAIL, e.to_string())
+	};
+	*type_info = TypeInfo::new_sys(
+		fact.datum_type,
+		fact.shape
+			.to_tvec()
+			.into_iter()
+			.map(|dim| match dim {
+				TDim::Val(size) => size,
+				_ => -1
+			})
+			.collect()
+	);
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn SessionGetOutputTypeInfo(session: *const OrtSession, index: usize, type_info: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	let session = unsafe { &*session.cast::<Session>() };
+	let (fact, label) = match session.original_graph.output_fact(index) {
+		Ok(fact) => (fact, session.outlet_labels.get(&session.original_graph.outputs[index]).unwrap()),
+		Err(e) => return Error::new_sys(OrtErrorCode::ORT_FAIL, e.to_string())
+	};
+	*type_info = TypeInfo::new_sys(
+		fact.datum_type,
+		fact.shape
+			.to_tvec()
+			.into_iter()
+			.map(|dim| match dim {
+				TDim::Val(size) => size,
+				_ => -1
+			})
+			.collect()
+	);
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn SessionGetOverridableInitializerTypeInfo(session: *const OrtSession, index: usize, type_info: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetInputName(
+	session: *const OrtSession,
+	index: usize,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	let session = unsafe { &*session.cast::<Session>() };
+	let name = match session.outlet_labels.get(&session.original_graph.inputs[index]) {
+		Some(name) => CString::new(name.to_owned()).unwrap(),
+		None => return Error::new_sys(OrtErrorCode::ORT_FAIL, format!("Invalid input #{}", index + 1))
+	};
+	*value = name.into_raw();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn SessionGetOutputName(
+	session: *const OrtSession,
+	index: usize,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	let session = unsafe { &*session.cast::<Session>() };
+	let name = match session.outlet_labels.get(&session.original_graph.outputs[index]) {
+		Some(name) => CString::new(name.to_owned()).unwrap(),
+		None => return Error::new_sys(OrtErrorCode::ORT_FAIL, format!("Invalid output #{}", index + 1))
+	};
+	*value = name.into_raw();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn SessionGetOverridableInitializerName(
+	session: *const OrtSession,
+	index: usize,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateRunOptions(out: *mut *mut OrtRunOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsSetRunLogVerbosityLevel(options: *mut OrtRunOptions, log_verbosity_level: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsSetRunLogSeverityLevel(options: *mut OrtRunOptions, log_severity_level: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsSetRunTag(options: *mut OrtRunOptions, run_tag: *const ::std::os::raw::c_char) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsGetRunLogVerbosityLevel(options: *const OrtRunOptions, log_verbosity_level: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsGetRunLogSeverityLevel(options: *const OrtRunOptions, log_severity_level: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsGetRunTag(options: *const OrtRunOptions, run_tag: *mut *const ::std::os::raw::c_char) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsSetTerminate(options: *mut OrtRunOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunOptionsUnsetTerminate(options: *mut OrtRunOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateTensorAsOrtValue(
+	allocator: *mut OrtAllocator,
+	shape: *const i64,
+	shape_len: usize,
+	type_: ONNXTensorElementDataType,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	let allocator = unsafe { &*allocator.cast::<Allocator>() };
+	let shape: Vec<usize> = unsafe { std::slice::from_raw_parts(shape, shape_len) }
+		.iter()
+		.copied()
+		.map(|c| c as usize)
+		.collect();
+	let dtype = match convert_sys_to_datum_type(type_) {
+		Ok(dtype) => dtype,
+		Err(e) => return e.into_sys()
+	};
+	match Tensor::zero_dt(dtype, &shape) {
+		Ok(tensor) => {
+			*out = (Box::leak(Box::new(tensor)) as *mut Tensor).cast();
+			ptr::null_mut()
+		}
+		Err(e) => Error::new_sys(OrtErrorCode::ORT_EP_FAIL, format!("Failed to create tensor: {e}"))
+	}
+}
+
+unsafe extern "system" fn CreateTensorWithDataAsOrtValue(
+	info: *const OrtMemoryInfo,
+	p_data: *mut ::std::os::raw::c_void,
+	p_data_len: usize,
+	shape: *const i64,
+	shape_len: usize,
+	type_: ONNXTensorElementDataType,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	let data_slice = unsafe { std::slice::from_raw_parts(p_data.cast::<u8>(), p_data_len) };
+	let shape: Vec<usize> = unsafe { std::slice::from_raw_parts(shape, shape_len) }
+		.iter()
+		.copied()
+		.map(|c| c as usize)
+		.collect();
+	let dtype = match convert_sys_to_datum_type(type_) {
+		Ok(dtype) => dtype,
+		Err(e) => return e.into_sys()
+	};
+	match Tensor::from_raw_dt(dtype, &shape, data_slice) {
+		Ok(tensor) => {
+			*out = (Box::leak(Box::new(tensor)) as *mut Tensor).cast();
+			ptr::null_mut()
+		}
+		Err(e) => Error::new_sys(OrtErrorCode::ORT_EP_FAIL, format!("Failed to create tensor: {e}"))
+	}
+}
+
+unsafe extern "system" fn IsTensor(value: *const OrtValue, out: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	*out = 1;
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn GetTensorMutableData(value: *mut OrtValue, out: *mut *mut ::std::os::raw::c_void) -> OrtStatusPtr {
+	let tensor = unsafe { &mut *value.cast::<Tensor>() };
+	*out = tensor.as_bytes_mut().as_mut_ptr().cast();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn FillStringTensor(value: *mut OrtValue, s: *const *const ::std::os::raw::c_char, s_len: usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetStringTensorDataLength(value: *const OrtValue, len: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetStringTensorContent(
+	value: *const OrtValue,
+	s: *mut ::std::os::raw::c_void,
+	s_len: usize,
+	offsets: *mut usize,
+	offsets_len: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CastTypeInfoToTensorInfo(type_info: *const OrtTypeInfo, out: *mut *const OrtTensorTypeAndShapeInfo) -> OrtStatusPtr {
+	*out = type_info.cast();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn GetOnnxTypeFromTypeInfo(type_info: *const OrtTypeInfo, out: *mut ONNXType) -> OrtStatusPtr {
+	*out = ONNXType::ONNX_TYPE_TENSOR;
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn CreateTensorTypeAndShapeInfo(out: *mut *mut OrtTensorTypeAndShapeInfo) -> OrtStatusPtr {
+	*out = TypeInfo::new_sys(DatumType::F32, Vec::new()).cast();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn SetTensorElementType(info: *mut OrtTensorTypeAndShapeInfo, type_: ONNXTensorElementDataType) -> OrtStatusPtr {
+	let info = unsafe { &mut *info.cast::<TypeInfo>() };
+	match convert_sys_to_datum_type(type_) {
+		Ok(dtype) => {
+			info.dtype = dtype;
+			ptr::null_mut()
+		}
+		Err(e) => e.into_sys()
+	}
+}
+
+unsafe extern "system" fn SetDimensions(info: *mut OrtTensorTypeAndShapeInfo, dim_values: *const i64, dim_count: usize) -> OrtStatusPtr {
+	let info = unsafe { &mut *info.cast::<TypeInfo>() };
+	info.shape = unsafe { std::slice::from_raw_parts(dim_values.cast(), dim_count) }.to_vec();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn GetTensorElementType(info: *const OrtTensorTypeAndShapeInfo, out: *mut ONNXTensorElementDataType) -> OrtStatusPtr {
+	let info = unsafe { &*info.cast::<TypeInfo>() };
+	*out = convert_datum_type_to_sys(info.dtype);
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn GetDimensionsCount(info: *const OrtTensorTypeAndShapeInfo, out: *mut usize) -> OrtStatusPtr {
+	let info = unsafe { &*info.cast::<TypeInfo>() };
+	*out = info.shape.len();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn GetDimensions(info: *const OrtTensorTypeAndShapeInfo, dim_values: *mut i64, dim_values_length: usize) -> OrtStatusPtr {
+	let info = unsafe { &*info.cast::<TypeInfo>() };
+	for (i, dim) in info.shape.iter().enumerate().take(dim_values_length) {
+		*dim_values.add(i) = *dim as _;
+	}
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn GetSymbolicDimensions(
+	info: *const OrtTensorTypeAndShapeInfo,
+	dim_params: *mut *const ::std::os::raw::c_char,
+	dim_params_length: usize
+) -> OrtStatusPtr {
+	for i in 0..dim_params_length {
+		*dim_params.add(i) = ptr::null();
+	}
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn GetTensorShapeElementCount(info: *const OrtTensorTypeAndShapeInfo, out: *mut usize) -> OrtStatusPtr {
+	let info = unsafe { &*info.cast::<TypeInfo>() };
+	let mut size = 1usize;
+	for dim in &info.shape {
+		size *= *dim as usize;
+	}
+	*out = size;
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn GetTensorTypeAndShape(value: *const OrtValue, out: *mut *mut OrtTensorTypeAndShapeInfo) -> OrtStatusPtr {
+	let tensor = unsafe { &*value.cast::<Tensor>() };
+	*out = TypeInfo::new_sys(tensor.datum_type(), tensor.shape().iter().map(|c| *c as i64).collect()).cast();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn GetTypeInfo(value: *const OrtValue, out: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	let tensor = unsafe { &*value.cast::<Tensor>() };
+	*out = TypeInfo::new_sys(tensor.datum_type(), tensor.shape().iter().map(|c| *c as i64).collect());
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn GetValueType(value: *const OrtValue, out: *mut ONNXType) -> OrtStatusPtr {
+	*out = ONNXType::ONNX_TYPE_TENSOR;
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn CreateMemoryInfo(
+	name: *const ::std::os::raw::c_char,
+	type_: OrtAllocatorType,
+	id: ::std::os::raw::c_int,
+	mem_type: OrtMemType,
+	out: *mut *mut OrtMemoryInfo
+) -> OrtStatusPtr {
+	let device_name = unsafe { CStr::from_ptr(name) };
+	let device_name = device_name.to_string_lossy();
+	if device_name != "Cpu" {
+		return Error::new(OrtErrorCode::ORT_ENGINE_ERROR, format!("tract does not support the '{device_name}' device")).into_sys();
+	}
+	unsafe { *out = ptr::dangling_mut() };
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn CreateCpuMemoryInfo(type_: OrtAllocatorType, mem_type: OrtMemType, out: *mut *mut OrtMemoryInfo) -> OrtStatusPtr {
+	unsafe { *out = ptr::dangling_mut() };
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn CompareMemoryInfo(info1: *const OrtMemoryInfo, info2: *const OrtMemoryInfo, out: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	*out = 0;
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn MemoryInfoGetName(ptr: *const OrtMemoryInfo, out: *mut *const ::std::os::raw::c_char) -> OrtStatusPtr {
+	*out = b"Cpu\0".as_ptr().cast();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn MemoryInfoGetId(ptr: *const OrtMemoryInfo, out: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	*out = 0;
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn MemoryInfoGetMemType(ptr: *const OrtMemoryInfo, out: *mut OrtMemType) -> OrtStatusPtr {
+	*out = OrtMemType::OrtMemTypeDefault;
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn MemoryInfoGetType(ptr: *const OrtMemoryInfo, out: *mut OrtAllocatorType) -> OrtStatusPtr {
+	*out = OrtAllocatorType::OrtDeviceAllocator;
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn AllocatorAlloc(ort_allocator: *mut OrtAllocator, size: usize, out: *mut *mut ::std::os::raw::c_void) -> OrtStatusPtr {
+	*out = unsafe { &*ort_allocator }.Alloc.unwrap()(ort_allocator, size);
+	if unsafe { *out }.is_null() {
+		return Error::new_sys(OrtErrorCode::ORT_RUNTIME_EXCEPTION, "Allocation failed");
+	}
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn AllocatorFree(ort_allocator: *mut OrtAllocator, p: *mut ::std::os::raw::c_void) -> OrtStatusPtr {
+	unsafe { &*ort_allocator }.Free.unwrap()(ort_allocator, p);
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn AllocatorGetInfo(ort_allocator: *const OrtAllocator, out: *mut *const OrtMemoryInfo) -> OrtStatusPtr {
+	*out = unsafe { &*ort_allocator }.Info.unwrap()(ort_allocator);
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn GetAllocatorWithDefaultOptions(out: *mut *mut OrtAllocator) -> OrtStatusPtr {
+	*out = (&crate::memory::DEFAULT_CPU_ALLOCATOR as *const Allocator).cast_mut().cast();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn AddFreeDimensionOverride(
+	options: *mut OrtSessionOptions,
+	dim_denotation: *const ::std::os::raw::c_char,
+	dim_value: i64
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetValue(
+	value: *const OrtValue,
+	index: ::std::os::raw::c_int,
+	allocator: *mut OrtAllocator,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetValueCount(value: *const OrtValue, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateValue(in_: *const *const OrtValue, num_values: usize, value_type: ONNXType, out: *mut *mut OrtValue) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateOpaqueValue(
+	domain_name: *const ::std::os::raw::c_char,
+	type_name: *const ::std::os::raw::c_char,
+	data_container: *const ::std::os::raw::c_void,
+	data_container_size: usize,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetOpaqueValue(
+	domain_name: *const ::std::os::raw::c_char,
+	type_name: *const ::std::os::raw::c_char,
+	in_: *const OrtValue,
+	data_container: *mut ::std::os::raw::c_void,
+	data_container_size: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetAttribute_float(info: *const OrtKernelInfo, name: *const ::std::os::raw::c_char, out: *mut f32) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetAttribute_int64(info: *const OrtKernelInfo, name: *const ::std::os::raw::c_char, out: *mut i64) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetAttribute_string(
+	info: *const OrtKernelInfo,
+	name: *const ::std::os::raw::c_char,
+	out: *mut ::std::os::raw::c_char,
+	size: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetInputCount(context: *const OrtKernelContext, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetOutputCount(context: *const OrtKernelContext, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetInput(context: *const OrtKernelContext, index: usize, out: *mut *const OrtValue) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetOutput(
+	context: *mut OrtKernelContext,
+	index: usize,
+	dim_values: *const i64,
+	dim_count: usize,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseEnv(input: *mut OrtEnv) {
+	drop(Environment::consume_sys(input));
+}
+
+unsafe extern "system" fn ReleaseStatus(input: *mut OrtStatus) {
+	drop(Error::consume_sys(input));
+}
+
+unsafe extern "system" fn ReleaseMemoryInfo(input: *mut OrtMemoryInfo) {}
+
+unsafe extern "system" fn ReleaseSession(input: *mut OrtSession) {
+	drop(unsafe { Box::<Session>::from_raw(input.cast()) });
+}
+
+unsafe extern "system" fn ReleaseValue(input: *mut OrtValue) {
+	drop(unsafe { Box::<Tensor>::from_raw(input.cast()) });
+}
+
+unsafe extern "system" fn ReleaseRunOptions(input: *mut OrtRunOptions) {}
+
+unsafe extern "system" fn ReleaseTypeInfo(input: *mut OrtTypeInfo) {
+	drop(TypeInfo::consume_sys(input));
+}
+
+unsafe extern "system" fn ReleaseTensorTypeAndShapeInfo(input: *mut OrtTensorTypeAndShapeInfo) {
+	drop(TypeInfo::consume_sys(input.cast()));
+}
+
+unsafe extern "system" fn ReleaseSessionOptions(input: *mut OrtSessionOptions) {
+	drop(Box::from_raw(input.cast::<SessionOptions>()));
+}
+
+unsafe extern "system" fn ReleaseCustomOpDomain(input: *mut OrtCustomOpDomain) {}
+
+unsafe extern "system" fn GetDenotationFromTypeInfo(
+	type_info: *const OrtTypeInfo,
+	denotation: *mut *const ::std::os::raw::c_char,
+	len: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CastTypeInfoToMapTypeInfo(type_info: *const OrtTypeInfo, out: *mut *const OrtMapTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CastTypeInfoToSequenceTypeInfo(type_info: *const OrtTypeInfo, out: *mut *const OrtSequenceTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetMapKeyType(map_type_info: *const OrtMapTypeInfo, out: *mut ONNXTensorElementDataType) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetMapValueType(map_type_info: *const OrtMapTypeInfo, type_info: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSequenceElementType(sequence_type_info: *const OrtSequenceTypeInfo, type_info: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseMapTypeInfo(input: *mut OrtMapTypeInfo) {}
+
+unsafe extern "system" fn ReleaseSequenceTypeInfo(input: *mut OrtSequenceTypeInfo) {}
+
+unsafe extern "system" fn SessionEndProfiling(session: *mut OrtSession, allocator: *mut OrtAllocator, out: *mut *mut ::std::os::raw::c_char) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetModelMetadata(session: *const OrtSession, out: *mut *mut OrtModelMetadata) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ModelMetadataGetProducerName(
+	model_metadata: *const OrtModelMetadata,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ModelMetadataGetGraphName(
+	model_metadata: *const OrtModelMetadata,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ModelMetadataGetDomain(
+	model_metadata: *const OrtModelMetadata,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ModelMetadataGetDescription(
+	model_metadata: *const OrtModelMetadata,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ModelMetadataLookupCustomMetadataMap(
+	model_metadata: *const OrtModelMetadata,
+	allocator: *mut OrtAllocator,
+	key: *const ::std::os::raw::c_char,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ModelMetadataGetVersion(model_metadata: *const OrtModelMetadata, value: *mut i64) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseModelMetadata(input: *mut OrtModelMetadata) {}
+
+unsafe extern "system" fn CreateEnvWithGlobalThreadPools(
+	log_severity_level: OrtLoggingLevel,
+	logid: *const ::std::os::raw::c_char,
+	tp_options: *const OrtThreadingOptions,
+	out: *mut *mut OrtEnv
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn DisablePerSessionThreads(options: *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateThreadingOptions(out: *mut *mut OrtThreadingOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseThreadingOptions(input: *mut OrtThreadingOptions) {}
+
+unsafe extern "system" fn ModelMetadataGetCustomMetadataMapKeys(
+	model_metadata: *const OrtModelMetadata,
+	allocator: *mut OrtAllocator,
+	keys: *mut *mut *mut ::std::os::raw::c_char,
+	num_keys: *mut i64
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddFreeDimensionOverrideByName(
+	options: *mut OrtSessionOptions,
+	dim_name: *const ::std::os::raw::c_char,
+	dim_value: i64
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetAvailableProviders(out_ptr: *mut *mut *mut ::std::os::raw::c_char, provider_length: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseAvailableProviders(ptr: *mut *mut ::std::os::raw::c_char, providers_length: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetStringTensorElementLength(value: *const OrtValue, index: usize, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetStringTensorElement(value: *const OrtValue, s_len: usize, index: usize, s: *mut ::std::os::raw::c_void) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn FillStringTensorElement(value: *mut OrtValue, s: *const ::std::os::raw::c_char, index: usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddSessionConfigEntry(
+	options: *mut OrtSessionOptions,
+	config_key: *const ::std::os::raw::c_char,
+	config_value: *const ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateAllocator(session: *const OrtSession, mem_info: *const OrtMemoryInfo, out: *mut *mut OrtAllocator) -> OrtStatusPtr {
+	*out = (Box::leak(Box::new(Allocator::new())) as *mut Allocator).cast();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn ReleaseAllocator(input: *mut OrtAllocator) {
+	drop(Box::from_raw(input.cast::<Allocator>()));
+}
+
+unsafe extern "system" fn RunWithBinding(session: *mut OrtSession, run_options: *const OrtRunOptions, binding_ptr: *const OrtIoBinding) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateIoBinding(session: *mut OrtSession, out: *mut *mut OrtIoBinding) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseIoBinding(input: *mut OrtIoBinding) {}
+
+unsafe extern "system" fn BindInput(binding_ptr: *mut OrtIoBinding, name: *const ::std::os::raw::c_char, val_ptr: *const OrtValue) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn BindOutput(binding_ptr: *mut OrtIoBinding, name: *const ::std::os::raw::c_char, val_ptr: *const OrtValue) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn BindOutputToDevice(
+	binding_ptr: *mut OrtIoBinding,
+	name: *const ::std::os::raw::c_char,
+	mem_info_ptr: *const OrtMemoryInfo
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetBoundOutputNames(
+	binding_ptr: *const OrtIoBinding,
+	allocator: *mut OrtAllocator,
+	buffer: *mut *mut ::std::os::raw::c_char,
+	lengths: *mut *mut usize,
+	count: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetBoundOutputValues(
+	binding_ptr: *const OrtIoBinding,
+	allocator: *mut OrtAllocator,
+	output: *mut *mut *mut OrtValue,
+	output_count: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ClearBoundInputs(binding_ptr: *mut OrtIoBinding) {}
+
+unsafe extern "system" fn ClearBoundOutputs(binding_ptr: *mut OrtIoBinding) {}
+
+unsafe extern "system" fn TensorAt(
+	value: *mut OrtValue,
+	location_values: *const i64,
+	location_values_count: usize,
+	out: *mut *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateAndRegisterAllocator(env: *mut OrtEnv, mem_info: *const OrtMemoryInfo, arena_cfg: *const OrtArenaCfg) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetLanguageProjection(ort_env: *const OrtEnv, projection: OrtLanguageProjection) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionGetProfilingStartTimeNs(session: *const OrtSession, out: *mut u64) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalIntraOpNumThreads(tp_options: *mut OrtThreadingOptions, intra_op_num_threads: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalInterOpNumThreads(tp_options: *mut OrtThreadingOptions, inter_op_num_threads: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalSpinControl(tp_options: *mut OrtThreadingOptions, allow_spinning: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddInitializer(options: *mut OrtSessionOptions, name: *const ::std::os::raw::c_char, val: *const OrtValue) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateEnvWithCustomLoggerAndGlobalThreadPools(
+	logging_function: OrtLoggingFunction,
+	logger_param: *mut ::std::os::raw::c_void,
+	log_severity_level: OrtLoggingLevel,
+	logid: *const ::std::os::raw::c_char,
+	tp_options: *const OrtThreadingOptions,
+	out: *mut *mut OrtEnv
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_CUDA(
+	options: *mut OrtSessionOptions,
+	cuda_options: *const OrtCUDAProviderOptions
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_ROCM(
+	options: *mut OrtSessionOptions,
+	rocm_options: *const OrtROCMProviderOptions
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_OpenVINO(
+	options: *mut OrtSessionOptions,
+	provider_options: *const OrtOpenVINOProviderOptions
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalDenormalAsZero(tp_options: *mut OrtThreadingOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateArenaCfg(
+	max_mem: usize,
+	arena_extend_strategy: ::std::os::raw::c_int,
+	initial_chunk_size_bytes: ::std::os::raw::c_int,
+	max_dead_bytes_per_chunk: ::std::os::raw::c_int,
+	out: *mut *mut OrtArenaCfg
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseArenaCfg(input: *mut OrtArenaCfg) {}
+
+unsafe extern "system" fn ModelMetadataGetGraphDescription(
+	model_metadata: *const OrtModelMetadata,
+	allocator: *mut OrtAllocator,
+	value: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_TensorRT(
+	options: *mut OrtSessionOptions,
+	tensorrt_options: *const OrtTensorRTProviderOptions
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetCurrentGpuDeviceId(device_id: ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetCurrentGpuDeviceId(device_id: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetAttributeArray_float(
+	info: *const OrtKernelInfo,
+	name: *const ::std::os::raw::c_char,
+	out: *mut f32,
+	size: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetAttributeArray_int64(
+	info: *const OrtKernelInfo,
+	name: *const ::std::os::raw::c_char,
+	out: *mut i64,
+	size: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateArenaCfgV2(
+	arena_config_keys: *const *const ::std::os::raw::c_char,
+	arena_config_values: *const usize,
+	num_keys: usize,
+	out: *mut *mut OrtArenaCfg
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddRunConfigEntry(
+	options: *mut OrtRunOptions,
+	config_key: *const ::std::os::raw::c_char,
+	config_value: *const ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreatePrepackedWeightsContainer(out: *mut *mut OrtPrepackedWeightsContainer) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleasePrepackedWeightsContainer(input: *mut OrtPrepackedWeightsContainer) {}
+
+unsafe extern "system" fn CreateSessionWithPrepackedWeightsContainer(
+	env: *const OrtEnv,
+	model_path: *const ortchar,
+	options: *const OrtSessionOptions,
+	prepacked_weights_container: *mut OrtPrepackedWeightsContainer,
+	out: *mut *mut OrtSession
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateSessionFromArrayWithPrepackedWeightsContainer(
+	env: *const OrtEnv,
+	model_data: *const ::std::os::raw::c_void,
+	model_data_length: usize,
+	options: *const OrtSessionOptions,
+	prepacked_weights_container: *mut OrtPrepackedWeightsContainer,
+	out: *mut *mut OrtSession
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_TensorRT_V2(
+	options: *mut OrtSessionOptions,
+	tensorrt_options: *const OrtTensorRTProviderOptionsV2
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateTensorRTProviderOptions(out: *mut *mut OrtTensorRTProviderOptionsV2) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UpdateTensorRTProviderOptions(
+	tensorrt_options: *mut OrtTensorRTProviderOptionsV2,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetTensorRTProviderOptionsAsString(
+	tensorrt_options: *const OrtTensorRTProviderOptionsV2,
+	allocator: *mut OrtAllocator,
+	ptr: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseTensorRTProviderOptions(input: *mut OrtTensorRTProviderOptionsV2) {}
+
+unsafe extern "system" fn EnableOrtCustomOps(options: *mut OrtSessionOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RegisterAllocator(env: *mut OrtEnv, allocator: *mut OrtAllocator) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UnregisterAllocator(env: *mut OrtEnv, mem_info: *const OrtMemoryInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn IsSparseTensor(value: *const OrtValue, out: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateSparseTensorAsOrtValue(
+	allocator: *mut OrtAllocator,
+	dense_shape: *const i64,
+	dense_shape_len: usize,
+	type_: ONNXTensorElementDataType,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn FillSparseTensorCoo(
+	ort_value: *mut OrtValue,
+	data_mem_info: *const OrtMemoryInfo,
+	values_shape: *const i64,
+	values_shape_len: usize,
+	values: *const ::std::os::raw::c_void,
+	indices_data: *const i64,
+	indices_num: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn FillSparseTensorCsr(
+	ort_value: *mut OrtValue,
+	data_mem_info: *const OrtMemoryInfo,
+	values_shape: *const i64,
+	values_shape_len: usize,
+	values: *const ::std::os::raw::c_void,
+	inner_indices_data: *const i64,
+	inner_indices_num: usize,
+	outer_indices_data: *const i64,
+	outer_indices_num: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn FillSparseTensorBlockSparse(
+	ort_value: *mut OrtValue,
+	data_mem_info: *const OrtMemoryInfo,
+	values_shape: *const i64,
+	values_shape_len: usize,
+	values: *const ::std::os::raw::c_void,
+	indices_shape_data: *const i64,
+	indices_shape_len: usize,
+	indices_data: *const i32
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateSparseTensorWithValuesAsOrtValue(
+	info: *const OrtMemoryInfo,
+	p_data: *mut ::std::os::raw::c_void,
+	dense_shape: *const i64,
+	dense_shape_len: usize,
+	values_shape: *const i64,
+	values_shape_len: usize,
+	type_: ONNXTensorElementDataType,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UseCooIndices(ort_value: *mut OrtValue, indices_data: *mut i64, indices_num: usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UseCsrIndices(
+	ort_value: *mut OrtValue,
+	inner_data: *mut i64,
+	inner_num: usize,
+	outer_data: *mut i64,
+	outer_num: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UseBlockSparseIndices(
+	ort_value: *mut OrtValue,
+	indices_shape: *const i64,
+	indices_shape_len: usize,
+	indices_data: *mut i32
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSparseTensorFormat(ort_value: *const OrtValue, out: *mut OrtSparseFormat) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSparseTensorValuesTypeAndShape(ort_value: *const OrtValue, out: *mut *mut OrtTensorTypeAndShapeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSparseTensorValues(ort_value: *const OrtValue, out: *mut *const ::std::os::raw::c_void) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSparseTensorIndicesTypeShape(
+	ort_value: *const OrtValue,
+	indices_format: OrtSparseIndicesFormat,
+	out: *mut *mut OrtTensorTypeAndShapeInfo
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSparseTensorIndices(
+	ort_value: *const OrtValue,
+	indices_format: OrtSparseIndicesFormat,
+	num_indices: *mut usize,
+	indices: *mut *const ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn HasValue(value: *const OrtValue, out: *mut ::std::os::raw::c_int) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetGPUComputeStream(context: *const OrtKernelContext, out: *mut *mut ::std::os::raw::c_void) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetTensorMemoryInfo(value: *const OrtValue, mem_info: *mut *const OrtMemoryInfo) -> OrtStatusPtr {
+	*mem_info = ptr::dangling();
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn GetExecutionProviderApi(
+	provider_name: *const ::std::os::raw::c_char,
+	version: u32,
+	provider_api: *mut *const ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsSetCustomCreateThreadFn(
+	options: *mut OrtSessionOptions,
+	ort_custom_create_thread_fn: OrtCustomCreateThreadFn
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsSetCustomThreadCreationOptions(
+	options: *mut OrtSessionOptions,
+	ort_custom_thread_creation_options: *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsSetCustomJoinThreadFn(
+	options: *mut OrtSessionOptions,
+	ort_custom_join_thread_fn: OrtCustomJoinThreadFn
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalCustomCreateThreadFn(
+	tp_options: *mut OrtThreadingOptions,
+	ort_custom_create_thread_fn: OrtCustomCreateThreadFn
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalCustomThreadCreationOptions(
+	tp_options: *mut OrtThreadingOptions,
+	ort_custom_thread_creation_options: *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalCustomJoinThreadFn(tp_options: *mut OrtThreadingOptions, ort_custom_join_thread_fn: OrtCustomJoinThreadFn) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SynchronizeBoundInputs(binding_ptr: *mut OrtIoBinding) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SynchronizeBoundOutputs(binding_ptr: *mut OrtIoBinding) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_CUDA_V2(
+	options: *mut OrtSessionOptions,
+	cuda_options: *const OrtCUDAProviderOptionsV2
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateCUDAProviderOptions(out: *mut *mut OrtCUDAProviderOptionsV2) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UpdateCUDAProviderOptions(
+	cuda_options: *mut OrtCUDAProviderOptionsV2,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetCUDAProviderOptionsAsString(
+	cuda_options: *const OrtCUDAProviderOptionsV2,
+	allocator: *mut OrtAllocator,
+	ptr: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseCUDAProviderOptions(input: *mut OrtCUDAProviderOptionsV2) {}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_MIGraphX(
+	options: *mut OrtSessionOptions,
+	migraphx_options: *const OrtMIGraphXProviderOptions
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddExternalInitializers(
+	options: *mut OrtSessionOptions,
+	initializer_names: *const *const ::std::os::raw::c_char,
+	initializers: *const *const OrtValue,
+	initializers_num: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateOpAttr(
+	name: *const ::std::os::raw::c_char,
+	data: *const ::std::os::raw::c_void,
+	len: ::std::os::raw::c_int,
+	type_: OrtOpAttrType,
+	op_attr: *mut *mut OrtOpAttr
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseOpAttr(input: *mut OrtOpAttr) {}
+
+unsafe extern "system" fn CreateOp(
+	info: *const OrtKernelInfo,
+	op_name: *const ::std::os::raw::c_char,
+	domain: *const ::std::os::raw::c_char,
+	version: ::std::os::raw::c_int,
+	type_constraint_names: *mut *const ::std::os::raw::c_char,
+	type_constraint_values: *const ONNXTensorElementDataType,
+	type_constraint_count: ::std::os::raw::c_int,
+	attr_values: *const *const OrtOpAttr,
+	attr_count: ::std::os::raw::c_int,
+	input_count: ::std::os::raw::c_int,
+	output_count: ::std::os::raw::c_int,
+	ort_op: *mut *mut OrtOp
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn InvokeOp(
+	context: *const OrtKernelContext,
+	ort_op: *const OrtOp,
+	input_values: *const *const OrtValue,
+	input_count: ::std::os::raw::c_int,
+	output_values: *const *mut OrtValue,
+	output_count: ::std::os::raw::c_int
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseOp(input: *mut OrtOp) {}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider(
+	options: *mut OrtSessionOptions,
+	provider_name: *const ::std::os::raw::c_char,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CopyKernelInfo(info: *const OrtKernelInfo, info_copy: *mut *mut OrtKernelInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseKernelInfo(input: *mut OrtKernelInfo) {}
+
+unsafe extern "system" fn GetTrainingApi(version: u32) -> *const OrtTrainingApi {
+	ptr::null()
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_CANN(
+	options: *mut OrtSessionOptions,
+	cann_options: *const OrtCANNProviderOptions
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateCANNProviderOptions(out: *mut *mut OrtCANNProviderOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UpdateCANNProviderOptions(
+	cann_options: *mut OrtCANNProviderOptions,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetCANNProviderOptionsAsString(
+	cann_options: *const OrtCANNProviderOptions,
+	allocator: *mut OrtAllocator,
+	ptr: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseCANNProviderOptions(input: *mut OrtCANNProviderOptions) {}
+
+unsafe extern "system" fn MemoryInfoGetDeviceType(ptr: *const OrtMemoryInfo, out: *mut OrtMemoryInfoDeviceType) {
+	*out = OrtMemoryInfoDeviceType::OrtMemoryInfoDeviceType_CPU;
+}
+
+unsafe extern "system" fn UpdateEnvWithCustomLogLevel(ort_env: *mut OrtEnv, log_severity_level: OrtLoggingLevel) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetGlobalIntraOpThreadAffinity(tp_options: *mut OrtThreadingOptions, affinity_string: *const ::std::os::raw::c_char) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RegisterCustomOpsLibrary_V2(options: *mut OrtSessionOptions, library_name: *const ortchar) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RegisterCustomOpsUsingFunction(
+	options: *mut OrtSessionOptions,
+	registration_func_name: *const ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfo_GetInputCount(info: *const OrtKernelInfo, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfo_GetOutputCount(info: *const OrtKernelInfo, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfo_GetInputName(
+	info: *const OrtKernelInfo,
+	index: usize,
+	out: *mut ::std::os::raw::c_char,
+	size: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfo_GetOutputName(
+	info: *const OrtKernelInfo,
+	index: usize,
+	out: *mut ::std::os::raw::c_char,
+	size: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfo_GetInputTypeInfo(info: *const OrtKernelInfo, index: usize, type_info: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfo_GetOutputTypeInfo(info: *const OrtKernelInfo, index: usize, type_info: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetAttribute_tensor(
+	info: *const OrtKernelInfo,
+	name: *const ::std::os::raw::c_char,
+	allocator: *mut OrtAllocator,
+	out: *mut *mut OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn HasSessionConfigEntry(
+	options: *const OrtSessionOptions,
+	config_key: *const ::std::os::raw::c_char,
+	out: *mut ::std::os::raw::c_int
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetSessionConfigEntry(
+	options: *const OrtSessionOptions,
+	config_key: *const ::std::os::raw::c_char,
+	config_value: *mut ::std::os::raw::c_char,
+	size: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_Dnnl(
+	options: *mut OrtSessionOptions,
+	dnnl_options: *const OrtDnnlProviderOptions
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateDnnlProviderOptions(out: *mut *mut OrtDnnlProviderOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UpdateDnnlProviderOptions(
+	dnnl_options: *mut OrtDnnlProviderOptions,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetDnnlProviderOptionsAsString(
+	dnnl_options: *const OrtDnnlProviderOptions,
+	allocator: *mut OrtAllocator,
+	ptr: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseDnnlProviderOptions(input: *mut OrtDnnlProviderOptions) {}
+
+unsafe extern "system" fn KernelInfo_GetNodeName(info: *const OrtKernelInfo, out: *mut ::std::os::raw::c_char, size: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfo_GetLogger(info: *const OrtKernelInfo, logger: *mut *const OrtLogger) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetLogger(context: *const OrtKernelContext, logger: *mut *const OrtLogger) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn Logger_LogMessage(
+	logger: *const OrtLogger,
+	log_severity_level: OrtLoggingLevel,
+	message: *const ::std::os::raw::c_char,
+	file_path: *const ortchar,
+	line_number: ::std::os::raw::c_int,
+	func_name: *const ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn Logger_GetLoggingSeverityLevel(logger: *const OrtLogger, out: *mut OrtLoggingLevel) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetConstantInput_tensor(
+	info: *const OrtKernelInfo,
+	index: usize,
+	is_constant: *mut ::std::os::raw::c_int,
+	out: *mut *const OrtValue
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CastTypeInfoToOptionalTypeInfo(type_info: *const OrtTypeInfo, out: *mut *const OrtOptionalTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetOptionalContainedTypeInfo(optional_type_info: *const OrtOptionalTypeInfo, out: *mut *mut OrtTypeInfo) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetResizedStringTensorElementBuffer(
+	value: *mut OrtValue,
+	index: usize,
+	length_in_bytes: usize,
+	buffer: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetAllocator(
+	context: *const OrtKernelContext,
+	mem_info: *const OrtMemoryInfo,
+	out: *mut *mut OrtAllocator
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetBuildInfoString() -> *const ::std::os::raw::c_char {
+	concat!("ORT Build Info: backend=ort-candle, version=", env!("CARGO_PKG_VERSION"), "\0")
+		.as_ptr()
+		.cast()
+}
+
+unsafe extern "system" fn CreateROCMProviderOptions(out: *mut *mut OrtROCMProviderOptions) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UpdateROCMProviderOptions(
+	rocm_options: *mut OrtROCMProviderOptions,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetROCMProviderOptionsAsString(
+	rocm_options: *const OrtROCMProviderOptions,
+	allocator: *mut OrtAllocator,
+	ptr: *mut *mut ::std::os::raw::c_char
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseROCMProviderOptions(input: *mut OrtROCMProviderOptions) {}
+
+unsafe extern "system" fn CreateAndRegisterAllocatorV2(
+	env: *mut OrtEnv,
+	provider_type: *const ::std::os::raw::c_char,
+	mem_info: *const OrtMemoryInfo,
+	arena_cfg: *const OrtArenaCfg,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn RunAsync(
+	session: *mut OrtSession,
+	run_options: *const OrtRunOptions,
+	input_names: *const *const ::std::os::raw::c_char,
+	input: *const *const OrtValue,
+	input_len: usize,
+	output_names: *const *const ::std::os::raw::c_char,
+	output_names_len: usize,
+	output: *mut *mut OrtValue,
+	run_async_callback: RunAsyncCallbackFn,
+	user_data: *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UpdateTensorRTProviderOptionsWithValue(
+	tensorrt_options: *mut OrtTensorRTProviderOptionsV2,
+	key: *const ::std::os::raw::c_char,
+	value: *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetTensorRTProviderOptionsByName(
+	tensorrt_options: *const OrtTensorRTProviderOptionsV2,
+	key: *const ::std::os::raw::c_char,
+	ptr: *mut *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn UpdateCUDAProviderOptionsWithValue(
+	cuda_options: *mut OrtCUDAProviderOptionsV2,
+	key: *const ::std::os::raw::c_char,
+	value: *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn GetCUDAProviderOptionsByName(
+	cuda_options: *const OrtCUDAProviderOptionsV2,
+	key: *const ::std::os::raw::c_char,
+	ptr: *mut *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetResource(
+	context: *const OrtKernelContext,
+	resouce_version: ::std::os::raw::c_int,
+	resource_id: ::std::os::raw::c_int,
+	resource: *mut *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetUserLoggingFunction(
+	options: *mut OrtSessionOptions,
+	user_logging_function: OrtLoggingFunction,
+	user_logging_param: *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ShapeInferContext_GetInputCount(context: *const OrtShapeInferContext, out: *mut usize) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ShapeInferContext_GetInputTypeShape(
+	context: *const OrtShapeInferContext,
+	index: usize,
+	info: *mut *mut OrtTensorTypeAndShapeInfo
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ShapeInferContext_GetAttribute(
+	context: *const OrtShapeInferContext,
+	attr_name: *const ::std::os::raw::c_char,
+	attr: *mut *const OrtOpAttr
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ShapeInferContext_SetOutputTypeShape(
+	context: *const OrtShapeInferContext,
+	index: usize,
+	info: *const OrtTensorTypeAndShapeInfo
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetSymbolicDimensions(
+	info: *mut OrtTensorTypeAndShapeInfo,
+	dim_params: *mut *const ::std::os::raw::c_char,
+	dim_params_length: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReadOpAttr(
+	op_attr: *const OrtOpAttr,
+	type_: OrtOpAttrType,
+	data: *mut ::std::os::raw::c_void,
+	len: usize,
+	out: *mut usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetDeterministicCompute(options: *mut OrtSessionOptions, value: bool) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_ParallelFor(
+	context: *const OrtKernelContext,
+	fn_: unsafe extern "system" fn(arg1: *mut ::std::os::raw::c_void, arg2: usize),
+	total: usize,
+	num_batch: usize,
+	usr_data: *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_OpenVINO_V2(
+	options: *mut OrtSessionOptions,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SessionOptionsAppendExecutionProvider_VitisAI(
+	options: *mut OrtSessionOptions,
+	provider_options_keys: *const *const ::std::os::raw::c_char,
+	provider_options_values: *const *const ::std::os::raw::c_char,
+	num_keys: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelContext_GetScratchBuffer(
+	context: *const OrtKernelContext,
+	mem_info: *const OrtMemoryInfo,
+	count_or_bytes: usize,
+	out: *mut *mut ::std::os::raw::c_void
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn KernelInfoGetAllocator(info: *const OrtKernelInfo, mem_type: OrtMemType, out: *mut *mut OrtAllocator) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn AddExternalInitializersFromMemory(
+	options: *mut OrtSessionOptions,
+	external_initializer_file_names: *const *const ortchar,
+	external_initializer_file_buffer_array: *const *mut ::std::os::raw::c_char,
+	external_initializer_file_lengths: *const usize,
+	num_external_initializer_files: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateLoraAdapter(adapter_file_path: *const ortchar, allocator: *mut OrtAllocator, out: *mut *mut OrtLoraAdapter) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn CreateLoraAdapterFromArray(
+	bytes: *const ::std::os::raw::c_void,
+	num_bytes: usize,
+	allocator: *mut OrtAllocator,
+	out: *mut *mut OrtLoraAdapter
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn ReleaseLoraAdapter(input: *mut OrtLoraAdapter) {}
+
+unsafe extern "system" fn RunOptionsAddActiveLoraAdapter(options: *mut OrtRunOptions, adapter: *const OrtLoraAdapter) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+unsafe extern "system" fn SetEpDynamicOptions(
+	sess: *mut OrtSession,
+	keys: *const *const ::std::os::raw::c_char,
+	values: *const *const ::std::os::raw::c_char,
+	kv_len: usize
+) -> OrtStatusPtr {
+	Error::new_sys(OrtErrorCode::ORT_NOT_IMPLEMENTED, "Unimplemented")
+}
+
+pub fn api() -> OrtApi {
+	OrtApi {
+		CreateStatus,
+		GetErrorCode,
+		GetErrorMessage,
+		CreateEnv,
+		CreateEnvWithCustomLogger,
+		EnableTelemetryEvents,
+		DisableTelemetryEvents,
+		CreateSession,
+		CreateSessionFromArray,
+		Run,
+		CreateSessionOptions,
+		SetOptimizedModelFilePath,
+		CloneSessionOptions,
+		SetSessionExecutionMode,
+		EnableProfiling,
+		DisableProfiling,
+		EnableMemPattern,
+		DisableMemPattern,
+		EnableCpuMemArena,
+		DisableCpuMemArena,
+		SetSessionLogId,
+		SetSessionLogVerbosityLevel,
+		SetSessionLogSeverityLevel,
+		SetSessionGraphOptimizationLevel,
+		SetIntraOpNumThreads,
+		SetInterOpNumThreads,
+		CreateCustomOpDomain,
+		CustomOpDomain_Add,
+		AddCustomOpDomain,
+		RegisterCustomOpsLibrary,
+		SessionGetInputCount,
+		SessionGetOutputCount,
+		SessionGetOverridableInitializerCount,
+		SessionGetInputTypeInfo,
+		SessionGetOutputTypeInfo,
+		SessionGetOverridableInitializerTypeInfo,
+		SessionGetInputName,
+		SessionGetOutputName,
+		SessionGetOverridableInitializerName,
+		CreateRunOptions,
+		RunOptionsSetRunLogVerbosityLevel,
+		RunOptionsSetRunLogSeverityLevel,
+		RunOptionsSetRunTag,
+		RunOptionsGetRunLogVerbosityLevel,
+		RunOptionsGetRunLogSeverityLevel,
+		RunOptionsGetRunTag,
+		RunOptionsSetTerminate,
+		RunOptionsUnsetTerminate,
+		CreateTensorAsOrtValue,
+		CreateTensorWithDataAsOrtValue,
+		IsTensor,
+		GetTensorMutableData,
+		FillStringTensor,
+		GetStringTensorDataLength,
+		GetStringTensorContent,
+		CastTypeInfoToTensorInfo,
+		GetOnnxTypeFromTypeInfo,
+		CreateTensorTypeAndShapeInfo,
+		SetTensorElementType,
+		SetDimensions,
+		GetTensorElementType,
+		GetDimensionsCount,
+		GetDimensions,
+		GetSymbolicDimensions,
+		GetTensorShapeElementCount,
+		GetTensorTypeAndShape,
+		GetTypeInfo,
+		GetValueType,
+		CreateMemoryInfo,
+		CreateCpuMemoryInfo,
+		CompareMemoryInfo,
+		MemoryInfoGetName,
+		MemoryInfoGetId,
+		MemoryInfoGetMemType,
+		MemoryInfoGetType,
+		AllocatorAlloc,
+		AllocatorFree,
+		AllocatorGetInfo,
+		GetAllocatorWithDefaultOptions,
+		AddFreeDimensionOverride,
+		GetValue,
+		GetValueCount,
+		CreateValue,
+		CreateOpaqueValue,
+		GetOpaqueValue,
+		KernelInfoGetAttribute_float,
+		KernelInfoGetAttribute_int64,
+		KernelInfoGetAttribute_string,
+		KernelContext_GetInputCount,
+		KernelContext_GetOutputCount,
+		KernelContext_GetInput,
+		KernelContext_GetOutput,
+		ReleaseEnv,
+		ReleaseStatus,
+		ReleaseMemoryInfo,
+		ReleaseSession,
+		ReleaseValue,
+		ReleaseRunOptions,
+		ReleaseTypeInfo,
+		ReleaseTensorTypeAndShapeInfo,
+		ReleaseSessionOptions,
+		ReleaseCustomOpDomain,
+		GetDenotationFromTypeInfo,
+		CastTypeInfoToMapTypeInfo,
+		CastTypeInfoToSequenceTypeInfo,
+		GetMapKeyType,
+		GetMapValueType,
+		GetSequenceElementType,
+		ReleaseMapTypeInfo,
+		ReleaseSequenceTypeInfo,
+		SessionEndProfiling,
+		SessionGetModelMetadata,
+		ModelMetadataGetProducerName,
+		ModelMetadataGetGraphName,
+		ModelMetadataGetDomain,
+		ModelMetadataGetDescription,
+		ModelMetadataLookupCustomMetadataMap,
+		ModelMetadataGetVersion,
+		ReleaseModelMetadata,
+		CreateEnvWithGlobalThreadPools,
+		DisablePerSessionThreads,
+		CreateThreadingOptions,
+		ReleaseThreadingOptions,
+		ModelMetadataGetCustomMetadataMapKeys,
+		AddFreeDimensionOverrideByName,
+		GetAvailableProviders,
+		ReleaseAvailableProviders,
+		GetStringTensorElementLength,
+		GetStringTensorElement,
+		FillStringTensorElement,
+		AddSessionConfigEntry,
+		CreateAllocator,
+		ReleaseAllocator,
+		RunWithBinding,
+		CreateIoBinding,
+		ReleaseIoBinding,
+		BindInput,
+		BindOutput,
+		BindOutputToDevice,
+		GetBoundOutputNames,
+		GetBoundOutputValues,
+		ClearBoundInputs,
+		ClearBoundOutputs,
+		TensorAt,
+		CreateAndRegisterAllocator,
+		SetLanguageProjection,
+		SessionGetProfilingStartTimeNs,
+		SetGlobalIntraOpNumThreads,
+		SetGlobalInterOpNumThreads,
+		SetGlobalSpinControl,
+		AddInitializer,
+		CreateEnvWithCustomLoggerAndGlobalThreadPools,
+		SessionOptionsAppendExecutionProvider_CUDA,
+		SessionOptionsAppendExecutionProvider_ROCM,
+		SessionOptionsAppendExecutionProvider_OpenVINO,
+		SetGlobalDenormalAsZero,
+		CreateArenaCfg,
+		ReleaseArenaCfg,
+		ModelMetadataGetGraphDescription,
+		SessionOptionsAppendExecutionProvider_TensorRT,
+		SetCurrentGpuDeviceId,
+		GetCurrentGpuDeviceId,
+		KernelInfoGetAttributeArray_float,
+		KernelInfoGetAttributeArray_int64,
+		CreateArenaCfgV2,
+		AddRunConfigEntry,
+		CreatePrepackedWeightsContainer,
+		ReleasePrepackedWeightsContainer,
+		CreateSessionWithPrepackedWeightsContainer,
+		CreateSessionFromArrayWithPrepackedWeightsContainer,
+		SessionOptionsAppendExecutionProvider_TensorRT_V2,
+		CreateTensorRTProviderOptions,
+		UpdateTensorRTProviderOptions,
+		GetTensorRTProviderOptionsAsString,
+		ReleaseTensorRTProviderOptions,
+		EnableOrtCustomOps,
+		RegisterAllocator,
+		UnregisterAllocator,
+		IsSparseTensor,
+		CreateSparseTensorAsOrtValue,
+		FillSparseTensorCoo,
+		FillSparseTensorCsr,
+		FillSparseTensorBlockSparse,
+		CreateSparseTensorWithValuesAsOrtValue,
+		UseCooIndices,
+		UseCsrIndices,
+		UseBlockSparseIndices,
+		GetSparseTensorFormat,
+		GetSparseTensorValuesTypeAndShape,
+		GetSparseTensorValues,
+		GetSparseTensorIndicesTypeShape,
+		GetSparseTensorIndices,
+		HasValue,
+		KernelContext_GetGPUComputeStream,
+		GetTensorMemoryInfo,
+		GetExecutionProviderApi,
+		SessionOptionsSetCustomCreateThreadFn,
+		SessionOptionsSetCustomThreadCreationOptions,
+		SessionOptionsSetCustomJoinThreadFn,
+		SetGlobalCustomCreateThreadFn,
+		SetGlobalCustomThreadCreationOptions,
+		SetGlobalCustomJoinThreadFn,
+		SynchronizeBoundInputs,
+		SynchronizeBoundOutputs,
+		SessionOptionsAppendExecutionProvider_CUDA_V2,
+		CreateCUDAProviderOptions,
+		UpdateCUDAProviderOptions,
+		GetCUDAProviderOptionsAsString,
+		ReleaseCUDAProviderOptions,
+		SessionOptionsAppendExecutionProvider_MIGraphX,
+		AddExternalInitializers,
+		CreateOpAttr,
+		ReleaseOpAttr,
+		CreateOp,
+		InvokeOp,
+		ReleaseOp,
+		SessionOptionsAppendExecutionProvider,
+		CopyKernelInfo,
+		ReleaseKernelInfo,
+		GetTrainingApi,
+		SessionOptionsAppendExecutionProvider_CANN,
+		CreateCANNProviderOptions,
+		UpdateCANNProviderOptions,
+		GetCANNProviderOptionsAsString,
+		ReleaseCANNProviderOptions,
+		MemoryInfoGetDeviceType,
+		UpdateEnvWithCustomLogLevel,
+		SetGlobalIntraOpThreadAffinity,
+		RegisterCustomOpsLibrary_V2,
+		RegisterCustomOpsUsingFunction,
+		KernelInfo_GetInputCount,
+		KernelInfo_GetOutputCount,
+		KernelInfo_GetInputName,
+		KernelInfo_GetOutputName,
+		KernelInfo_GetInputTypeInfo,
+		KernelInfo_GetOutputTypeInfo,
+		KernelInfoGetAttribute_tensor,
+		HasSessionConfigEntry,
+		GetSessionConfigEntry,
+		SessionOptionsAppendExecutionProvider_Dnnl,
+		CreateDnnlProviderOptions,
+		UpdateDnnlProviderOptions,
+		GetDnnlProviderOptionsAsString,
+		ReleaseDnnlProviderOptions,
+		KernelInfo_GetNodeName,
+		KernelInfo_GetLogger,
+		KernelContext_GetLogger,
+		Logger_LogMessage,
+		Logger_GetLoggingSeverityLevel,
+		KernelInfoGetConstantInput_tensor,
+		CastTypeInfoToOptionalTypeInfo,
+		GetOptionalContainedTypeInfo,
+		GetResizedStringTensorElementBuffer,
+		KernelContext_GetAllocator,
+		GetBuildInfoString,
+		CreateROCMProviderOptions,
+		UpdateROCMProviderOptions,
+		GetROCMProviderOptionsAsString,
+		ReleaseROCMProviderOptions,
+		CreateAndRegisterAllocatorV2,
+		RunAsync,
+		UpdateTensorRTProviderOptionsWithValue,
+		GetTensorRTProviderOptionsByName,
+		UpdateCUDAProviderOptionsWithValue,
+		GetCUDAProviderOptionsByName,
+		KernelContext_GetResource,
+		SetUserLoggingFunction,
+		ShapeInferContext_GetInputCount,
+		ShapeInferContext_GetInputTypeShape,
+		ShapeInferContext_GetAttribute,
+		ShapeInferContext_SetOutputTypeShape,
+		SetSymbolicDimensions,
+		ReadOpAttr,
+		SetDeterministicCompute,
+		KernelContext_ParallelFor,
+		SessionOptionsAppendExecutionProvider_OpenVINO_V2,
+		SessionOptionsAppendExecutionProvider_VitisAI,
+		KernelContext_GetScratchBuffer,
+		KernelInfoGetAllocator,
+		AddExternalInitializersFromMemory,
+		CreateLoraAdapter,
+		CreateLoraAdapterFromArray,
+		ReleaseLoraAdapter,
+		RunOptionsAddActiveLoraAdapter,
+		SetEpDynamicOptions
+	}
+}

--- a/backends/tract/api.rs
+++ b/backends/tract/api.rs
@@ -79,7 +79,7 @@ unsafe extern "system" fn CreateSession(
 		OsString::from_wide(path)
 	};
 	#[cfg(not(target_os = "windows"))]
-	let path = OsString::from_encoded_bytes_unchecked(path.to_vec());
+	let path = OsString::from_encoded_bytes_unchecked(path.iter().map(|c| *c as u8).collect::<Vec<_>>());
 
 	let buf = match fs::read(path) {
 		Ok(buf) => buf,

--- a/backends/tract/error.rs
+++ b/backends/tract/error.rs
@@ -1,0 +1,42 @@
+use std::ffi::{CString, c_char};
+
+#[derive(Debug, Clone)]
+pub struct Error {
+	pub code: ort_sys::OrtErrorCode,
+	message: CString
+}
+
+impl Error {
+	pub fn new(code: ort_sys::OrtErrorCode, message: impl Into<String>) -> Self {
+		Self {
+			code,
+			message: CString::new(message.into()).unwrap()
+		}
+	}
+
+	pub fn into_sys(self) -> *mut ort_sys::OrtStatus {
+		(Box::leak(Box::new(self)) as *mut Error).cast()
+	}
+
+	pub fn new_sys(code: ort_sys::OrtErrorCode, message: impl Into<String>) -> *mut ort_sys::OrtStatus {
+		Self::new(code, message).into_sys()
+	}
+
+	#[inline]
+	pub fn message(&self) -> &str {
+		self.message.as_c_str().to_str().unwrap()
+	}
+
+	#[inline]
+	pub fn message_ptr(&self) -> *const c_char {
+		self.message.as_ptr()
+	}
+
+	pub unsafe fn cast_from_sys<'e>(ptr: *const ort_sys::OrtStatus) -> &'e Error {
+		unsafe { &*ptr.cast::<Error>() }
+	}
+
+	pub unsafe fn consume_sys(ptr: *mut ort_sys::OrtStatus) -> Box<Error> {
+		Box::from_raw(ptr.cast::<Error>())
+	}
+}

--- a/backends/tract/error.rs
+++ b/backends/tract/error.rs
@@ -23,11 +23,6 @@ impl Error {
 	}
 
 	#[inline]
-	pub fn message(&self) -> &str {
-		self.message.as_c_str().to_str().unwrap()
-	}
-
-	#[inline]
 	pub fn message_ptr(&self) -> *const c_char {
 		self.message.as_ptr()
 	}

--- a/backends/tract/lib.rs
+++ b/backends/tract/lib.rs
@@ -1,0 +1,67 @@
+use ort_sys::OrtErrorCode;
+use tract_onnx::{Onnx, prelude::DatumType};
+
+mod api;
+pub(crate) mod error;
+mod memory;
+mod session;
+mod tensor;
+
+pub use self::api::api;
+use self::error::Error;
+
+pub(crate) struct Environment {
+	pub onnx: Onnx
+}
+
+impl Environment {
+	pub fn new_sys() -> *mut ort_sys::OrtEnv {
+		(Box::leak(Box::new(Self { onnx: tract_onnx::onnx() })) as *mut Environment).cast()
+	}
+
+	pub unsafe fn cast_from_sys<'e>(ptr: *const ort_sys::OrtEnv) -> &'e Environment {
+		unsafe { &*ptr.cast::<Environment>() }
+	}
+
+	pub unsafe fn consume_sys(ptr: *mut ort_sys::OrtEnv) -> Box<Environment> {
+		Box::from_raw(ptr.cast::<Environment>())
+	}
+}
+
+fn convert_sys_to_datum_type(sys: ort_sys::ONNXTensorElementDataType) -> Result<DatumType, Error> {
+	match sys {
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL => Ok(DatumType::Bool),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8 => Ok(DatumType::U8),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16 => Ok(DatumType::U16),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32 => Ok(DatumType::U32),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64 => Ok(DatumType::U64),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8 => Ok(DatumType::I8),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16 => Ok(DatumType::I16),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32 => Ok(DatumType::I32),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64 => Ok(DatumType::I64),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 => Ok(DatumType::F16),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT => Ok(DatumType::F32),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE => Ok(DatumType::F64),
+		ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING => Ok(DatumType::String),
+		_ => Err(Error::new(OrtErrorCode::ORT_FAIL, "Element type not supported by tract"))
+	}
+}
+
+fn convert_datum_type_to_sys(dtype: DatumType) -> ort_sys::ONNXTensorElementDataType {
+	match dtype {
+		DatumType::Bool => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL,
+		DatumType::U8 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8,
+		DatumType::U16 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16,
+		DatumType::U32 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32,
+		DatumType::U64 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64,
+		DatumType::I8 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8,
+		DatumType::I16 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16,
+		DatumType::I32 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32,
+		DatumType::I64 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64,
+		DatumType::F16 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+		DatumType::F32 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT,
+		DatumType::F64 => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE,
+		DatumType::String => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING,
+		_ => ort_sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED
+	}
+}

--- a/backends/tract/lib.rs
+++ b/backends/tract/lib.rs
@@ -19,10 +19,6 @@ impl Environment {
 		(Box::leak(Box::new(Self { onnx: tract_onnx::onnx() })) as *mut Environment).cast()
 	}
 
-	pub unsafe fn cast_from_sys<'e>(ptr: *const ort_sys::OrtEnv) -> &'e Environment {
-		unsafe { &*ptr.cast::<Environment>() }
-	}
-
 	pub unsafe fn consume_sys(ptr: *mut ort_sys::OrtEnv) -> Box<Environment> {
 		Box::from_raw(ptr.cast::<Environment>())
 	}

--- a/backends/tract/memory.rs
+++ b/backends/tract/memory.rs
@@ -1,0 +1,39 @@
+use std::{ffi::CString, ptr};
+
+#[repr(C)]
+pub struct Allocator {
+	_sys_api: ort_sys::OrtAllocator
+}
+
+impl Allocator {
+	pub const fn new() -> Self {
+		Self {
+			_sys_api: ort_sys::OrtAllocator {
+				version: ort_sys::ORT_API_VERSION,
+				Alloc: Some(sys_allocator_alloc),
+				Free: Some(sys_allocator_free),
+				Info: Some(sys_allocator_info),
+				Reserve: Some(sys_allocator_reserve)
+			}
+		}
+	}
+}
+
+pub static DEFAULT_CPU_ALLOCATOR: Allocator = Allocator::new();
+
+unsafe extern "system" fn sys_allocator_alloc(_this: *mut ort_sys::OrtAllocator, _size: usize) -> *mut ::std::os::raw::c_void {
+	ptr::null_mut()
+}
+
+unsafe extern "system" fn sys_allocator_free(_this: *mut ort_sys::OrtAllocator, p: *mut ::std::os::raw::c_void) {
+	drop(CString::from_raw(p.cast()));
+}
+
+unsafe extern "system" fn sys_allocator_info(this_: *const ort_sys::OrtAllocator) -> *const ort_sys::OrtMemoryInfo {
+	let _allocator = unsafe { &*this_.cast::<Allocator>() };
+	ptr::dangling()
+}
+
+unsafe extern "system" fn sys_allocator_reserve(_this: *const ort_sys::OrtAllocator, _size: usize) -> *mut ::std::os::raw::c_void {
+	ptr::null_mut()
+}

--- a/backends/tract/session.rs
+++ b/backends/tract/session.rs
@@ -1,0 +1,30 @@
+use std::{collections::HashMap, path::Path};
+
+use tract_onnx::prelude::{Framework, Graph, InferenceModel, InferenceModelExt, OutletId, Tensor, TractResult, TypedFact, TypedOp};
+
+use crate::{Environment, error::Error};
+
+type OptimizedGraph = Graph<TypedFact, Box<dyn TypedOp>>;
+
+#[derive(Default, Clone)]
+pub struct SessionOptions {
+	pub perform_optimizations: bool
+}
+
+pub struct Session {
+	pub outlet_labels: HashMap<OutletId, String>,
+	pub original_graph: OptimizedGraph
+}
+
+impl Session {
+	pub fn from_buffer(env: &Environment, options: &SessionOptions, mut data: &[u8]) -> TractResult<Session> {
+		let model = env.onnx.model_for_read(&mut data)?;
+		let outlet_labels = model.outlet_labels.clone();
+		let graph = if options.perform_optimizations { model.into_optimized()? } else { model.into_typed()? };
+		Ok(Session { outlet_labels, original_graph: graph })
+	}
+
+	pub fn run(&self, inputs: HashMap<String, Tensor>) -> TractResult<HashMap<String, Tensor>> {
+		unimplemented!()
+	}
+}

--- a/backends/tract/session.rs
+++ b/backends/tract/session.rs
@@ -1,30 +1,117 @@
-use std::{collections::HashMap, path::Path};
+use std::{
+	collections::{HashMap, hash_map::Entry},
+	hash::{BuildHasher, DefaultHasher, Hasher},
+	sync::Arc
+};
 
-use tract_onnx::prelude::{Framework, Graph, InferenceModel, InferenceModelExt, OutletId, Tensor, TractResult, TypedFact, TypedOp};
+use parking_lot::Mutex;
+use tract_onnx::{
+	pb::ValueInfoProto,
+	prelude::{Framework, Graph, InferenceModelExt, IntoTensor, SimplePlan, Tensor, TractResult, TypedFact, TypedOp}
+};
 
-use crate::{Environment, error::Error};
+use crate::Environment;
 
 type OptimizedGraph = Graph<TypedFact, Box<dyn TypedOp>>;
+type RunnableGraph = SimplePlan<TypedFact, Box<dyn TypedOp>, OptimizedGraph>;
 
 #[derive(Default, Clone)]
 pub struct SessionOptions {
 	pub perform_optimizations: bool
 }
 
+pub struct SessionLockedInner {
+	original_graph: Arc<OptimizedGraph>,
+	graphs: HashMap<u64, RunnableGraph, PassthroughHashBuilder>
+}
+
+impl SessionLockedInner {
+	pub fn new(original_graph: Arc<OptimizedGraph>) -> Self {
+		Self {
+			original_graph,
+			graphs: HashMap::with_hasher(PassthroughHashBuilder)
+		}
+	}
+
+	pub fn get_graph(&mut self, inputs: &[(String, Tensor)]) -> TractResult<&mut RunnableGraph> {
+		let input_mark = Session::hash_inputs(inputs);
+		match self.graphs.entry(input_mark) {
+			Entry::Vacant(entry) => Ok(entry.insert(
+				OptimizedGraph::clone(&*self.original_graph)
+					.with_input_names(inputs.iter().map(|(n, _)| n))?
+					.into_runnable()?
+			)),
+			Entry::Occupied(entry) => Ok(entry.into_mut())
+		}
+	}
+}
+
 pub struct Session {
-	pub outlet_labels: HashMap<OutletId, String>,
-	pub original_graph: OptimizedGraph
+	pub inputs: Vec<ValueInfoProto>,
+	pub outputs: Vec<ValueInfoProto>,
+	pub original_graph: Arc<OptimizedGraph>,
+	locked_inner: Mutex<SessionLockedInner>
 }
 
 impl Session {
 	pub fn from_buffer(env: &Environment, options: &SessionOptions, mut data: &[u8]) -> TractResult<Session> {
-		let model = env.onnx.model_for_read(&mut data)?;
-		let outlet_labels = model.outlet_labels.clone();
-		let graph = if options.perform_optimizations { model.into_optimized()? } else { model.into_typed()? };
-		Ok(Session { outlet_labels, original_graph: graph })
+		let proto_model = env.onnx.proto_model_for_read(&mut data)?;
+		let inputs = proto_model.graph.as_ref().map(|graph| graph.input.clone()).unwrap_or_default();
+		let outputs = proto_model.graph.as_ref().map(|graph| graph.output.clone()).unwrap_or_default();
+
+		let model = env.onnx.model_for_proto_model(&proto_model)?;
+		let graph = Arc::new(if options.perform_optimizations { model.into_optimized()? } else { model.into_typed()? });
+		Ok(Session {
+			inputs,
+			outputs,
+			original_graph: Arc::clone(&graph),
+			locked_inner: Mutex::new(SessionLockedInner::new(graph))
+		})
 	}
 
-	pub fn run(&self, inputs: HashMap<String, Tensor>) -> TractResult<HashMap<String, Tensor>> {
-		unimplemented!()
+	fn hash_inputs(inputs: &[(String, Tensor)]) -> u64 {
+		let mut hasher = DefaultHasher::new();
+		for (name, _) in inputs {
+			hasher.write_u64(name.len() as _);
+			hasher.write(name.as_bytes());
+			hasher.write_u8(0);
+		}
+		hasher.finish()
+	}
+
+	pub fn run(&self, inputs: Vec<(String, Tensor)>) -> TractResult<Vec<(String, Tensor)>> {
+		let mut inner = self.locked_inner.lock();
+		let graph = inner.get_graph(&inputs)?;
+		let outputs = graph.run(inputs.into_iter().map(|(_, v)| tract_onnx::prelude::TValue::from(v)).collect())?;
+		Ok(outputs
+			.into_iter()
+			.enumerate()
+			.map(|(i, v)| (self.outputs[i].name.clone(), v.into_tensor()))
+			.collect())
+	}
+}
+
+struct PassthroughHasher(u64);
+
+impl Hasher for PassthroughHasher {
+	fn write(&mut self, _: &[u8]) {
+		unreachable!()
+	}
+
+	fn write_u64(&mut self, i: u64) {
+		self.0 = i;
+	}
+
+	fn finish(&self) -> u64 {
+		self.0
+	}
+}
+
+struct PassthroughHashBuilder;
+impl BuildHasher for PassthroughHashBuilder {
+	type Hasher = PassthroughHasher;
+
+	fn build_hasher(&self) -> Self::Hasher {
+		PassthroughHasher(0)
 	}
 }

--- a/backends/tract/tensor.rs
+++ b/backends/tract/tensor.rs
@@ -1,0 +1,16 @@
+use tract_onnx::prelude::DatumType;
+
+pub struct TypeInfo {
+	pub dtype: DatumType,
+	pub shape: Vec<i64>
+}
+
+impl TypeInfo {
+	pub fn new_sys(dtype: DatumType, shape: Vec<i64>) -> *mut ort_sys::OrtTypeInfo {
+		(Box::leak(Box::new(Self { dtype, shape })) as *mut TypeInfo).cast()
+	}
+
+	pub unsafe fn consume_sys(ptr: *mut ort_sys::OrtTypeInfo) -> Box<TypeInfo> {
+		Box::from_raw(ptr.cast::<TypeInfo>())
+	}
+}

--- a/backends/tract/tests/memory.rs
+++ b/backends/tract/tests/memory.rs
@@ -1,0 +1,16 @@
+use ort::memory::{AllocationDevice, Allocator, DeviceType};
+
+#[test]
+fn test_memory_info_apis() {
+	ort::set_api(ort_tract::api());
+
+	let allocator = Allocator::default();
+
+	let memory_info = allocator.memory_info();
+	assert_eq!(memory_info.allocation_device(), AllocationDevice::CPU);
+	assert_eq!(memory_info.device_type(), DeviceType::CPU);
+	assert_eq!(memory_info.device_id(), 0);
+
+	let memory_info_clone = memory_info.clone();
+	assert_eq!(memory_info, memory_info_clone);
+}

--- a/backends/tract/tests/session.rs
+++ b/backends/tract/tests/session.rs
@@ -1,0 +1,62 @@
+use std::path::Path;
+
+use image::{ImageBuffer, Luma, Pixel, imageops::FilterType};
+use ort::{
+	inputs,
+	session::{Session, builder::GraphOptimizationLevel},
+	tensor::ArrayExtensions,
+	value::TensorRef
+};
+
+#[test]
+fn mnist_5() -> ort::Result<()> {
+	const IMAGE_TO_LOAD: &str = "mnist_5.jpg";
+
+	ort::set_api(ort_tract::api());
+
+	let session = Session::builder()?
+		.with_optimization_level(GraphOptimizationLevel::Level3)?
+		.commit_from_url("https://parcel.pyke.io/v2/cdn/assetdelivery/ortrsv2/ex_models/mnist.onnx")
+		.expect("Could not download model from file");
+
+	// Load image and resize to model's shape, converting to RGB format
+	let image_buffer: ImageBuffer<Luma<u8>, Vec<u8>> = image::open(
+		Path::new(env!("CARGO_MANIFEST_DIR"))
+			.parent()
+			.unwrap()
+			.parent()
+			.unwrap()
+			.join("tests")
+			.join("data")
+			.join(IMAGE_TO_LOAD)
+	)
+	.unwrap()
+	.resize(28, 28, FilterType::Nearest)
+	.to_luma8();
+
+	let array = ndarray::Array::from_shape_fn((1, 1, 28, 28), |(_, c, j, i)| {
+		let pixel = image_buffer.get_pixel(i as u32, j as u32);
+		let channels = pixel.channels();
+
+		// range [0, 255] -> range [0, 1]
+		(channels[c] as f32) / 255.0
+	});
+
+	// Perform the inference
+	let outputs = session.run(inputs![TensorRef::from_array_view(&array)?])?;
+
+	let mut probabilities: Vec<(usize, f32)> = outputs[0]
+		.try_extract_tensor()?
+		.softmax(ndarray::Axis(1))
+		.iter()
+		.copied()
+		.enumerate()
+		.collect::<Vec<_>>();
+
+	// Sort probabilities so highest is at beginning of vector.
+	probabilities.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+
+	assert_eq!(probabilities[0].0, 5, "Expecting class for {} is '5' (not {})", IMAGE_TO_LOAD, probabilities[0].0);
+
+	Ok(())
+}

--- a/backends/tract/tests/tensor.rs
+++ b/backends/tract/tests/tensor.rs
@@ -1,0 +1,17 @@
+use ort::value::Tensor;
+
+#[test]
+fn test_tensors() -> ort::Result<()> {
+	ort::set_api(ort_tract::api());
+
+	let mut tensor = Tensor::<i64>::from_array((vec![5], vec![0, 1, 2, 3, 4]))?;
+	let ptr = tensor.data_ptr_mut()?.cast::<i64>();
+	unsafe {
+		*ptr.add(3) = 42;
+	};
+
+	let (_, extracted) = tensor.extract_raw_tensor();
+	assert_eq!(&extracted, &[0, 1, 2, 42, 4]);
+
+	Ok(())
+}


### PR DESCRIPTION
This PR adds runtimes other than *the* ONNX Runtime.

There are plenty of alternative ONNX inference engines for Rust that each provide their own unique qualities:
- [`candle`](https://github.com/huggingface/candle) boasts impressive performance and GPU acceleration.
- [`tract`](https://github.com/sonos/tract) is a battle-tested pure-Rust inference engine with excellent operator support.
- [`wonnx`](https://github.com/webonnx/wonnx) focuses on broader GPU support is designed for the web.

With the [removal of `wasm32-unknown-unknown` support from ort](https://github.com/pykeio/ort/commit/e2c454941b944a3bdb0a5df2f11cb997f50c2658), and the Sisyphean task of *getting the damn thing to link*, it's clear that ONNX Runtime isn't always the best choice. Most often, though, it *is* the best choice for one platform, but not another. Applications wishing to target CUDA on desktop and WebGPU on web would need to have 2 different code paths using `ort` and `wonnx`. Adding support for `wonnx` & others directly in `ort` would mean that developers only need to use the `ort` API to target both backends, and only a single line of code is required to switch between them, e.g. `ort::set_api(ort_candle::api());`

## Status
- [x] `ort-candle`
  - [x] PoC
  - [x] Tensor values
  - [x] Session creation
  - [x] Inference
  - [ ] ~~Alternative 'execution providers'~~ - appears to currently be unsupported by `candle-onnx`?
  - [ ] ~~`IoBinding`~~
- [x] `ort-tract`
  - [x] PoC
  - [x] Tensor values
  - [x] Session creation
  - [x] Inference
- [ ] `ort-wonnx`

<sub>p.s., [sponsorships](https://opencollective.com/pyke-osai) allow me to spend more time on this PR =)</sub>