### PR TITLE
Bump ndarray version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ort"
 description = "A Rust wrapper for ONNX Runtime 1.16 - Optimize and Accelerate Machine Learning Inferencing"
-version = "1.16.3"
+version = "1.16.4"
 edition = "2021"
 rust-version = "1.70"
 license = "MIT/Apache-2.0"
@@ -58,7 +58,7 @@ cann = []
 qnn = []
 
 [dependencies]
-ndarray = "0.15"
+ndarray = "0.16"
 thiserror = "1.0"
 libloading = { version = "0.7", optional = true }
 


### PR DESCRIPTION
We're using `ndarray` in this version 0.16 for our projects and a new release v1.16.4 with this dependency updated would help us eliminate some gnarly conversion code.