### PR TITLE
Making the wasm example work using tract

### DIFF
--- a/examples/wasm-emscripten/Cargo.toml
+++ b/examples/wasm-emscripten/Cargo.toml
@@ -9,10 +9,19 @@ path = "src/main.rs"
 name = "wasm_example"
 
 [dependencies]
-ort = { path = "../../", default-features = false, features = ["ndarray", "webgpu", "download-binaries"] }
+ort-tract = "0.1.0+0.21"
+#ort = { path = "../../", default-features = false, features = ["ndarray", "download-binaries"] }
 ndarray = "0.16"
 image = "0.25"
 
 [build-dependencies]
 glob = "0.3"
 reqwest = { version = "0.12", features = ["blocking"] }
+
+[dependencies.ort]
+version = "=2.0.0-rc.10"
+default-features = false # Disables the `download-binaries` feature since we don't need it
+features = [
+    "ndarray",
+    "alternative-backend"
+]

--- a/examples/wasm-emscripten/serve.py
+++ b/examples/wasm-emscripten/serve.py
@@ -23,6 +23,6 @@ class CORSRequestHandler (SimpleHTTPRequestHandler):
 
 # Serve index.html.
 chdir(path.join(path.dirname(__file__), f"target/wasm32-unknown-emscripten/{mode}"))
-httpd = HTTPServer(("localhost", 5555), CORSRequestHandler)
-print(f"Serving {mode} build at: http://localhost:5555")
+httpd = HTTPServer(("0.0.0.0", 5555), CORSRequestHandler)
+print(f"Serving {mode} build at: http://0.0.0.0:5555")
 httpd.serve_forever()

--- a/examples/wasm-emscripten/src/main.rs
+++ b/examples/wasm-emscripten/src/main.rs
@@ -39,6 +39,7 @@ pub extern "C" fn dealloc(ptr: *mut std::os::raw::c_void, size: usize) {
 
 #[no_mangle]
 pub extern "C" fn detect_objects(ptr: *const u8, width: u32, height: u32) {
+	ort::set_api(ort_tract::api());
 	ort::init()
 		.with_global_thread_pool(ort::environment::GlobalThreadPoolOptions::default())
 		.commit()


### PR DESCRIPTION
I know there's an upcoming version with [more support for webpgu/wasm](https://github.com/pykeio/ort/pull/347#issuecomment-3006402584), but I still wanted to try the wasm example to test the performance of the yolo model once my use case (run [insightface](https://github.com/deepinsight/insightface) using [rust-insightface](https://github.com/andrenatal/rust_insightface) on mobile) uses a similar(ish) model. So I decided to leave this here as reference. 

First I tried to just build the wasm example as is on current master but after adding the `"tls-rustls` feature it didn't compile due to some incompatibilities due to changes in the API.  

So I checked out the [commit](https://github.com/pykeio/ort/commit/75ec921a1e76f11f47546de85dabd446f470416b) of when it was merged and tried to build, but regardless if I remove or not the `webgpu` feature from the toml, it would fail with:

```
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: wasm-ld: error: lto.tmp: undefined symbol: emwgpuDelete
          wasm-ld: error: lto.tmp: undefined symbol: emwgpuDelete
          wasm-ld: error: lto.tmp: undefined symbol: emwgpuDelete
          wasm-ld: error: lto.tmp: undefined symbol: emwgpuDelete
          wasm-ld: error: lto.tmp: undefined symbol: emwgpuDelete
          wasm-ld: error: lto.tmp: undefined symbol: emwgpuDelete
          wasm-ld: error: lto.tmp: undefined symbol: emwgpuDelete
          wasm-ld: error: lto.tmp: undefined symbol: emwgpuDelete
          wasm-ld: error: lto.tmp: undefined symbol: emwgpuDelete
          wasm-ld: error: lto.tmp: undefined symbol: emwgpuDelete
          wasm-ld: error: lto.tmp: undefined symbol: emwgpuInstanceRequestAdapter
          wasm-ld: error: lto.tmp: undefined symbol: wgpuAdapterHasFeature
          wasm-ld: error: lto.tmp: undefined symbol: wgpuAdapterHasFeature
          wasm-ld: error: lto.tmp: undefined symbol: wgpuAdapterHasFeature
          wasm-ld: error: lto.tmp: undefined symbol: wgpuAdapterHasFeature
          wasm-ld: error: lto.tmp: undefined symbol: wgpuAdapterGetLimits
          wasm-ld: error: lto.tmp: undefined symbol: emwgpuDelete
          wasm-ld: error: lto.tmp: undefined symbol: emwgpuAdapterRequestDevice
          wasm-ld: error: lto.tmp: undefined symbol: emwgpuDelete
          wasm-ld: error: lto.tmp: undefined symbol: emwgpuDelete
          wasm-ld: error: too many errors emitted, stopping now (use -error-limit=0 to see all errors)
          emcc: error: '/Users/anatal/projects/ort/examples/wasm-emscripten/emsdk/upstream/bin/wasm-ld @/var/folders/pj/z7z01d851vqckn2cvkthcrsh0000gp/T/emscripten_qfztqmcq.rsp.utf-8' failed (returned 1)
```          

So the only way to run the wasm example was using the tract backend which is the body of this PR. It worked, but performance is insufferable -- 10 seconds to run inference. 

After we figure out webgpu I'll revisit this and try again, but I'll give another try with NLP models soon.
