### PR TITLE
docs(website): add supabase use case

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -28,6 +28,7 @@ Converting a neural network to a graph representation like ONNX opens the door t
 - [**Google's Magika**](https://github.com/google/magika) file type detection library is powered by `ort`.
 - [**Wasmtime**](https://github.com/bytecodealliance/wasmtime), an open-source WebAssembly runtime, supports ONNX inference for the [WASI-NN standard](https://github.com/WebAssembly/wasi-nn) via `ort`.
 - [**`rust-bert`**](https://github.com/guillaume-be/rust-bert) implements many ready-to-use NLP pipelines in Rust à la Hugging Face Transformers with both [`tch`](https://crates.io/crates/tch) & `ort` backends.
+- [**`Supabase`**](https://supabase.com)'s edge functions AI compatibility is powered by `ort`.
 
 # Getting started
 <Steps>


### PR DESCRIPTION
This PR add [Supabase](https://supabase.com) as case of history in the home page.

---

Notice that Supabase is already into gh readme, so it only changes the website.
