### PR TITLE
docs: add Koharu to FOSS projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,5 @@ When you need to deploy a PyTorch/TensorFlow/Keras/scikit-learn/PaddlePaddle mod
 - **[oar-ocr](https://github.com/GreatV/oar-ocr)** A comprehensive OCR library, built in Rust with `ort` for efficient inference.
 - **[Text Embeddings Inference (TEI)](https://github.com/huggingface/text-embeddings-inference)** uses `ort` to deliver high-performance ONNX runtime inference for text embedding models.
 - **[Flow-Like](https://github.com/TM9657/flow-like)** uses `ort` to enable local ML inference inside its typed workflow engine.
-- **[CamTrap Detector](https://github.com/bencevans/camtrap-detector)** uses `ort` to detect animals, humans and vehicles in trail camera imagery
+- **[CamTrap Detector](https://github.com/bencevans/camtrap-detector)** uses `ort` to detect animals, humans and vehicles in trail camera imagery.
+- **[Koharu](https://github.com/mayocream/koharu)** uses `ort` to detect, OCR, and inpaint manga pages.


### PR DESCRIPTION
Thanks for your great work, `ort` is easy to use and efficient.
I wanna add the project I am working on to the FOSS project list :)