### PR TITLE
Add migraphx_fp8_enable option to OrtMIGraphXProviderOptions

### DIFF
--- a/ort-sys/src/lib.rs
+++ b/ort-sys/src/lib.rs
@@ -532,6 +532,7 @@ pub struct OrtTensorRTProviderOptions {
 pub struct OrtMIGraphXProviderOptions {
 	pub device_id: core::ffi::c_int,
 	pub migraphx_fp16_enable: core::ffi::c_int,
+	pub migraphx_fp8_enable: core::ffi::c_int,
 	pub migraphx_int8_enable: core::ffi::c_int,
 	pub migraphx_use_native_calibration_table: core::ffi::c_int,
 	pub migraphx_int8_calibration_table_name: *const core::ffi::c_char,

--- a/src/ep/migraphx.rs
+++ b/src/ep/migraphx.rs
@@ -9,6 +9,7 @@ use crate::{ep::ArenaExtendStrategy, error::Result, session::builder::SessionBui
 pub struct MIGraphX {
 	device_id: i32,
 	enable_fp16: bool,
+	enable_fp8: bool,
 	enable_int8: bool,
 	use_native_calibration_table: bool,
 	int8_calibration_table_name: Option<CString>,
@@ -24,6 +25,7 @@ impl Default for MIGraphX {
 		Self {
 			device_id: 0,
 			enable_fp16: false,
+			enable_fp8: false,
 			enable_int8: false,
 			use_native_calibration_table: false,
 			int8_calibration_table_name: None,
@@ -66,6 +68,21 @@ impl MIGraphX {
 	#[must_use]
 	pub fn with_fp16(mut self, enable: bool) -> Self {
 		self.enable_fp16 = enable;
+		self
+	}
+
+	/// Enable FP8 quantization for the model.
+	///
+	/// ```
+	/// # use ort::{ep, session::Session};
+	/// # fn main() -> ort::Result<()> {
+	/// let ep = ep::MIGraphX::default().with_fp8(true).build();
+	/// # Ok(())
+	/// # }
+	/// ```
+	#[must_use]
+	pub fn with_fp8(mut self, enable: bool) -> Self {
+		self.enable_fp8 = enable;
 		self
 	}
 
@@ -185,6 +202,7 @@ impl ExecutionProvider for MIGraphX {
 			let options = ort_sys::OrtMIGraphXProviderOptions {
 				device_id: self.device_id,
 				migraphx_fp16_enable: self.enable_fp16.into(),
+				migraphx_fp8_enable: self.enable_fp8.into(),
 				migraphx_int8_enable: self.enable_int8.into(),
 				migraphx_use_native_calibration_table: self.use_native_calibration_table.into(),
 				migraphx_int8_calibration_table_name: self.int8_calibration_table_name.as_ref().map(|c| c.as_ptr()).unwrap_or_else(ptr::null),


### PR DESCRIPTION
This option should be there according to https://onnxruntime.ai/docs/api/c/struct_ort_m_i_graph_x_provider_options.html, tested on onnxruntime-rocm 1.23.2-3, migraphx 7.1.1-1.