### PR TITLE
Bump version of ort-tract to work with ort-sys>=2

### DIFF
--- a/docs/content/backends/tract.mdx
+++ b/docs/content/backends/tract.mdx
@@ -35,7 +35,7 @@ import { Steps } from 'nextra/components';
 ### Install `ort-tract`
 ```toml filename="Cargo.toml"
 [dependencies]
-ort-tract = "0.1.0+0.21"
+ort-tract = "0.2.0+0.21"
 ...
 ```
 


### PR DESCRIPTION
Cargo throws a version mismatch error, when using ort-tract "0.1.x" with ort >= 2.