### PR TITLE
patch: use i64 as value shape element ty

### DIFF
--- a/backends/web/binding/session.rs
+++ b/backends/web/binding/session.rs
@@ -211,7 +211,7 @@ impl InferenceSession {
 #[serde(untagged)]
 pub enum ShapeElement {
 	Named(String),
-	Value(i32)
+	Value(i64)
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
Fixes the following runtime panic:

```
backends/web/binding/session.rs:151:14:
called `Result::unwrap()` on an `Err` value: Error(JsValue(Error: data did not match any variant of untagged enum ShapeElement
Error: data did not match any variant of untagged enum ShapeElement
```