### PR TITLE
fix: add missing import

### DIFF
--- a/src/session/builder/impl_config_keys.rs
+++ b/src/session/builder/impl_config_keys.rs
@@ -1,4 +1,5 @@
 use super::{BuilderResult, SessionBuilder};
+use crate::alloc::string::ToString;
 
 // https://github.com/microsoft/onnxruntime/blob/main/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
 


### PR DESCRIPTION
The misc-checks cargo check command has an error due to no method named `to_string` found for type `u32` in the current scope. Add the missing import.