### PR TITLE
fix(directml): replace panic with error + validate fn ptrs in get_dml_api (ORT 1.24 regression)

### DIFF
--- a/src/ep/directml.rs
+++ b/src/ep/directml.rs
@@ -9,7 +9,23 @@ fn get_dml_api() -> Result<&'static ort_sys::OrtDmlApi> {
 	DML_API.get_or_try_init(|| {
 		let mut ptr: *const ort_sys::c_void = ptr::null();
 		ortsys![unsafe GetExecutionProviderApi(c"DML".as_ptr(), 0, &mut ptr)?];
-		assert!(!ptr.is_null());
+		if ptr.is_null() {
+			return Err(crate::Error::new("DirectML is not available"));
+		}
+		// ORT 1.24+ returns a non-null pointer to a zeroed OrtDmlApi when
+		// onnxruntime_providers_dml.dll is absent rather than returning null.
+		// Verify the first function pointer is populated before caching the table,
+		// since calling a null fn pointer is undefined behaviour and causes a crash.
+		// SAFETY: `ptr` is non-null; `OrtDmlApi` is #[repr(C)] so its first field
+		// (`SessionOptionsAppendExecutionProvider_DML`) is at offset 0 and has the
+		// same size and alignment as a pointer on all supported platforms.
+		let first_fn = unsafe { *ptr.cast::<*const ort_sys::c_void>() };
+		if first_fn.is_null() {
+			return Err(crate::Error::new(
+				"DirectML is not available: GetExecutionProviderApi returned an empty OrtDmlApi \
+				 function table; ensure onnxruntime_providers_dml.dll is present alongside onnxruntime.dll"
+			));
+		}
 		Ok(unsafe { (*ptr.cast::<ort_sys::OrtDmlApi>()).clone() })
 	})
 }


### PR DESCRIPTION
## Problem

ORT 1.24 changed the behaviour of `GetExecutionProviderApi("DML")` when `onnxruntime_providers_dml.dll` is absent. Instead of returning a null pointer (or an error status), it now returns a **non-null pointer to a zero-filled `OrtDmlApi` struct**.

The previous `get_dml_api()` code only checked `assert!(!ptr.is_null())`, which passes even when the DML DLL is missing. The zeroed `OrtDmlApi` is then cloned and cached.

Later, `register()` calls one of the function pointers in that zeroed struct. The specific pointer depends on `device_id`:

- `device_id = Some(n)` → calls `SessionOptionsAppendExecutionProvider_DML` (index 0)
- `device_id = None` → calls `SessionOptionsAppendExecutionProvider_DML2` (last field)

rc.12 changed `device_id` from `i32` (default `0`) to `Option<i32>` (default `None`), so `DirectML::default()` now always takes the `else` branch and calls `SessionOptionsAppendExecutionProvider_DML2`. That function pointer is null → **CALL 0x0 → access violation / SIGILL**.

With rc.11 this was invisible because `define_ep_register!` loaded the DML symbol dynamically at call time and returned a clean `RegisterError` if the symbol was missing.

## Reproducer

1. Build with `load-dynamic` or `directml` feature.
2. Point `ORT_DYLIB_PATH` at an `onnxruntime.dll` whose directory does **not** contain `onnxruntime_providers_dml.dll`.
3. Construct a session with `ep::DirectML::default()`.
4. Process crashes with an access violation at the first call site inside `get_dml_api` or in `register`.

Confirmed on Windows 11 / ORT 1.24.3 (CUDA NuGet package, which ships without the DML DLL).

## Fix

Two changes to `get_dml_api()`:

**1. Replace `assert!` with a proper `Err` return.**

`assert!` aborts the process; a library should return an error so callers can fall back gracefully. The `RegisterError::Error` path in `apply_execution_providers` already handles this correctly — it logs the failure and continues to the next provider.

**2. Validate the first function pointer before caching the struct.**

`OrtDmlApi` is `#[repr(C)]`, so its first field (`SessionOptionsAppendExecutionProvider_DML`) is at offset 0. Reading that field as a raw pointer before cloning the struct detects the zeroed-table case without undefined behaviour.

If the pointer is null we return a descriptive error that names the missing DLL.

```
error: DirectML is not available: GetExecutionProviderApi returned an empty OrtDmlApi
       function table; ensure onnxruntime_providers_dml.dll is present alongside onnxruntime.dll
```

This error propagates through `RegisterError::Error`, gets logged at ERROR level, and the session builder falls back to the next provider (CPU or otherwise) instead of crashing.

## What is not changed

- `register()` is unchanged — no extra null-guards are needed there once `get_dml_api()` refuses to cache a zeroed struct.
- Behaviour when `onnxruntime_providers_dml.dll` **is** present is identical to before.
- No changes to `ort-sys`.

## Testing

Verified with `cargo check --no-default-features --features load-dynamic,std` (clean, no new warnings) and `cargo check --no-default-features --features std` (unused-fn path also clean).