### PR TITLE
docs: add Xybrid to projects using ort

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ When you need to deploy a PyTorch/TensorFlow/Keras/scikit-learn/PaddlePaddle mod
 - **[Murmure](https://github.com/Kieirra/murmure)** uses `ort` as its core engine, leveraging NVIDIA Parakeet to deliver fully local, free, private and cross‑platform Speech‑to‑Text enhanced with LLM post‑processing.
 - **[Valentinus](https://github.com/kn0sys/valentinus)** uses `ort` to provide embedding model inference inside LMDB.
 - **[SilentKeys](https://github.com/gptguy/silentkeys)** uses `ort` for fast, on-device real-time dictation with NVIDIA Parakeet and Silero VAD.
+- **[Xybrid](https://github.com/xybrid-ai/xybrid)** uses `ort` to run LLMs, ASR, and TTS natively on-device across iOS, Android, Flutter, and Unity apps and games.


### PR DESCRIPTION
Adds [Xybrid](https://github.com/xybrid-ai/xybrid) to the list of FOSS projects using `ort`.

Xybrid is an Apache-2.0 licensed Rust runtime that runs LLMs, ASR, and TTS natively on-device across iOS, Android, Flutter, and Unity apps and games, using ONNX Runtime via `ort`.