### PR TITLE
fix(docs): correct typos in comments in various files

### DIFF
--- a/ort-sys/build/download/resolve.rs
+++ b/ort-sys/build/download/resolve.rs
@@ -72,7 +72,7 @@ pub fn resolve_dist() -> Result<Distribution, Option<String>> {
 	let mut dist = find_dist(&target, &feature_set);
 	if dist.is_none() && feature_set != "none" {
 		log::warning!("no prebuilt binaries available on this platform for combination of features '{feature_set}'");
-		// i dont like this behavior at all but the only thing i like less than it is rust-analyzer breaking because it
+		// I don't like this behavior at all but the only thing I like less than it is rust-analyzer breaking because it
 		// ***insists*** on enabling --all-features
 		dist = find_dist(&target, "none");
 	}

--- a/ort-sys/build/static_link/apple.rs
+++ b/ort-sys/build/static_link/apple.rs
@@ -49,7 +49,7 @@ fn search_and_link_frameworks_in_sub_dir(sub_dir: &str) -> bool {
 	let fwk_dir = Path::new(&xcfwk_dir).join(sub_dir);
 	if !fwk_dir.exists() {
 		log::warning!("framework directory '{}' does not exist", fwk_dir.display());
-		// Framework directory not found, dont add search path at all
+		// Framework directory not found, don't add search path at all
 		return false;
 	}
 	println!("cargo:rustc-link-search=framework={}", fwk_dir.display());
@@ -71,7 +71,7 @@ fn search_and_link_frameworks_in_sub_dir(sub_dir: &str) -> bool {
 
 	let ext_fwk_dir = Path::new(&ext_xcfwk_dir).join(sub_dir);
 	if !ext_fwk_dir.exists() {
-		// Extension framework directory not found, dont add search path at all
+		// Extension framework directory not found, don't add search path at all
 		return true;
 	}
 	println!("cargo:rustc-link-search=framework={}", ext_fwk_dir.display());

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -29,7 +29,7 @@
 //! ```
 //!
 //! If you don't configure an environment, one will be created with default settings at the first creation of a session.
-//! The environment can't be re-configured after one is committed, so it's important `ort::init` come before any other
+//! The environment can't be re-configured after one is committed, so it's important `ort::init` comes before any other
 //! `ort` API for the config to take effect. Authors of libraries using `ort` should **never** have the library
 //! configure the environment itself; allow the application developer to do that themselves if they wish.
 //!

--- a/src/ep/coreml.rs
+++ b/src/ep/coreml.rs
@@ -212,7 +212,7 @@ impl CoreML {
 	/// import onnx
 	/// import hashlib
 	///
-	/// # You can use any other hash algorithms to ensure the model and its hash-value is a one-one mapping.
+	/// # You can use any other hash algorithms to ensure the model and its hash-value is a one-to-one mapping.
 	/// def hash_file(file_path, algorithm='sha256', chunk_size=8192):
 	/// 	hash_func = hashlib.new(algorithm)
 	/// 	with open(file_path, 'rb') as file:

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -116,7 +116,7 @@ pub struct ValueRef<'v, Type: ValueTypeMarker + ?Sized = DynValueTypeMarker> {
 impl<'v, Type: ValueTypeMarker + ?Sized> ValueRef<'v, Type> {
 	pub(crate) fn new(inner: Value<Type>) -> Self {
 		ValueRef {
-			// We cannot upgade a value which we cannot drop, i.e. `ValueRef`s used in operator kernels. Those only last for the
+			// We cannot upgrade a value which we cannot drop, i.e. `ValueRef`s used in operator kernels. Those only last for the
 			// duration of the kernel, allowing an upgrade would allow a UAF.
 			upgradable: inner.inner.drop,
 			inner,
@@ -169,7 +169,7 @@ pub struct ValueRefMut<'v, Type: ValueTypeMarker + ?Sized = DynValueTypeMarker> 
 impl<'v, Type: ValueTypeMarker + ?Sized> ValueRefMut<'v, Type> {
 	pub(crate) fn new(inner: Value<Type>) -> Self {
 		ValueRefMut {
-			// We cannot upgade a value which we cannot drop, i.e. `ValueRef`s used in operator kernels. Those only last for the
+			// We cannot upgrade a value which we cannot drop, i.e. `ValueRef`s used in operator kernels. Those only last for the
 			// duration of the kernel, allowing an upgrade would allow a UAF.
 			upgradable: inner.inner.drop,
 			inner,


### PR DESCRIPTION
Hello 👋 I was just checking the repository and notice couple of simple typos, I hope that helps

Files are here 

- ort-sys/build/download/resolve.rs
- ort-sys/build/static_link/apple.rs
- src/environment.rs
- src/ep/coreml.rs
- src/value/mod.rs