### PR TITLE
native f16 for nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ training = [ "ort-sys/training" ]
 
 ndarray = [ "dep:ndarray" ]
 half = [ "dep:half" ]
+nightly = []
 num-complex = [ "dep:num-complex" ]
 tracing = [ "dep:tracing" ]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![warn(clippy::unwrap_used)]
 #![deny(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+#![cfg_attr(feature = "nightly", feature(f16))]
 
 //! <div align=center>
 //! 	<img src="https://parcel.pyke.io/v2/cdn/assetdelivery/ortrsv2/docs/trend-banner.png" width="350px">

--- a/src/value/impl_tensor/element.rs
+++ b/src/value/impl_tensor/element.rs
@@ -212,6 +212,8 @@ impl_type_trait!(bool, Bool);
 #[cfg(feature = "half")]
 #[cfg_attr(docsrs, doc(cfg(feature = "half")))]
 impl_type_trait!(half::f16, Float16);
+#[cfg(feature = "nightly")]
+impl_type_trait!(f16, Float16);
 impl_type_trait!(f64, Float64);
 impl_type_trait!(u32, Uint32);
 impl_type_trait!(u64, Uint64);
@@ -340,6 +342,10 @@ mod tests {
 		{
 			do_test!(Float16, half::f16, half::f16::from_f32(1.037813));
 			do_test!(Bfloat16, half::bf16, half::bf16::from_f32(39.18381));
+		}
+		#[cfg(feature = "nightly")]
+		{
+			do_test!(Float16, f16, 2.7);
 		}
 		#[cfg(feature = "num-complex")]
 		{


### PR DESCRIPTION
# native f16 for nightly

If you use this, the **as f16** conversion becomes free:
```toml
[build]
rustflags = ["-C", "target-feature=+f16c"]
```

## use feature = ["nightly"] to enable

native f16 avoids the overhead of conversion to half::f16