### PR TITLE
build: fix clang_rt linkage for mac catalyst

### DIFF
--- a/ort-sys/build/static_link/mod.rs
+++ b/ort-sys/build/static_link/mod.rs
@@ -37,7 +37,7 @@ pub fn static_link_prerequisites(source: BinariesSource) {
 		println!("cargo:rustc-link-lib=framework=Foundation");
 		println!("cargo:rustc-link-lib=framework=CoreML");
 
-		if target_triple.contains("apple-darwin")
+		if (target_triple.contains("apple-darwin") || target_triple.contains("apple-ios-macabi"))
 			&& let Some(dir) = apple::macos_rtlib_search_dir()
 		{
 			println!("cargo:rustc-link-search={dir}");


### PR DESCRIPTION
The mac catalyst target name is `arm64-apple-ios-macabi` & `x86_64-apple-ios-macabi`, we need to link to `osx` variant for mac catalyst.