### PR TITLE
fix(load-dynamic): add freebsd support to ORT_DYLIB_PATH dynamic load fallback

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ fn setup_api() -> ApiPointer {
 				Ok(s) if !s.is_empty() => s,
 				#[cfg(target_os = "windows")]
 				_ => "onnxruntime.dll".to_owned(),
-				#[cfg(any(target_os = "linux", target_os = "android"))]
+				#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 				_ => "libonnxruntime.so".to_owned(),
 				#[cfg(any(target_os = "macos", target_os = "ios"))]
 				_ => "libonnxruntime.dylib".to_owned()


### PR DESCRIPTION
  #### Description:
    This PR adds support for `target_os = "freebsd"` when compiling `ort` with the `load-dynamic` feature.

  #### Motivation
    When compiling a project using `ort` (such as `fastembed`) on a FreeBSD host with the `load-dynamic` feature active, compilation currently fails with Rust compiler error `E0004` (non-exhaustive patterns: `Err(_)` not covered).

    This happens because the `match` expression checking `ORT_DYLIB_PATH` in `src/lib.rs` has platform-conditional match arms, but does not list `target_os = "freebsd"`. Since FreeBSD uses standard ELF `.so` libraries for dynamic/shared objects (behaving like Linux and Android in this regard), this PR groups `freebsd` in the `.so` fallback match arm:

    ```rust
    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
    _ => "libonnxruntime.so".to_owned(),

  ### Checklist

  [✓] Compilation successfully verified on FreeBSD 15.1-stable.
  [✓] No breaking API changes introduced.