### PR TITLE
cleanup: fix unused code warnings and CI deprecation

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2.9.1
       - name: Get Rust version
         id: rust-version
-        run: echo "::set-output name=version::$(cargo --version | cut -d ' ' -f 2)"
+        run: echo "version=$(cargo --version | cut -d ' ' -f 2)" >> "$GITHUB_OUTPUT"
         shell: bash
       - uses: actions/cache@v5
         id: tarpaulin-cache

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub use ort_sys as sys;
 
 #[cfg(all(feature = "load-dynamic", not(target_arch = "wasm32")))]
 pub use self::environment::init_from;
-pub(crate) use self::logging::{debug, error, info, trace, warning as warn};
+pub(crate) use self::logging::{error, info, trace, warning as warn};
 #[cfg(test)]
 pub(crate) mod test_util;
 use self::util::OnceLock;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -46,12 +46,6 @@ macro_rules! trace {
 		tracing::trace!($($arg)+);
 	}}
 }
-macro_rules! debug {
-	($($arg:tt)+) => {{
-		#[cfg(feature = "tracing")]
-		tracing::debug!($($arg)+);
-	}}
-}
 macro_rules! info {
 	($($arg:tt)+) => {{
 		#[cfg(feature = "tracing")]
@@ -70,7 +64,6 @@ macro_rules! error {
 		tracing::error!($($arg)+);
 	}}
 }
-pub(crate) use debug;
 pub(crate) use error;
 pub(crate) use info;
 pub(crate) use trace;

--- a/src/value/impl_tensor/copy.rs
+++ b/src/value/impl_tensor/copy.rs
@@ -1,6 +1,7 @@
 //! ONNX Runtime doesn't (currently) expose an API for inter-device copies, so we instead use a dummy model to copy the
 //! tensor & `IoBinding` to configure where the copy ends up.
 
+#[cfg(any(feature = "cuda", feature = "directml", feature = "cann", feature = "openvino", feature = "rocm"))]
 use alloc::{format, string::ToString};
 use core::ops::{Deref, DerefMut};
 
@@ -32,6 +33,7 @@ static SESSIONS: OnceLock<Mutex<MiniMap<IdentitySessionKey, IdentitySession>>> =
 /// `RunOptions` with [`RunOptions::disable_device_sync`], shared across `to_async()` calls to reduce allocations.
 static IDENTITY_RUN_OPTIONS: OnceLock<RunOptions<NoSelectedOutputs>> = OnceLock::new();
 
+#[allow(unused_variables)]
 fn ep_for_device(device: AllocationDevice, device_id: i32) -> Result<ep::ExecutionProviderDispatch> {
 	Ok(match device {
 		AllocationDevice::CPU => ep::CPU::default().with_arena_allocator(false).build(),

--- a/src/value/type.rs
+++ b/src/value/type.rs
@@ -319,28 +319,6 @@ impl Outlet {
 		}
 	}
 
-	#[cfg(feature = "api-22")]
-	pub(crate) unsafe fn from_raw(raw: NonNull<ort_sys::OrtValueInfo>, drop: bool) -> Result<Self> {
-		let mut name = ptr::null();
-		ortsys![unsafe GetValueInfoName(raw.as_ptr(), &mut name)?];
-		let name = if !name.is_null() {
-			unsafe { CStr::from_ptr(name) }.to_str().map_or_else(|_| String::new(), str::to_string)
-		} else {
-			String::new()
-		};
-
-		let mut type_info = ptr::null();
-		ortsys![unsafe GetValueInfoTypeInfo(raw.as_ptr(), &mut type_info)?; nonNull(type_info)];
-		let dtype = unsafe { ValueType::from_type_info(type_info) };
-
-		Ok(Self {
-			name,
-			dtype,
-			value_info: Some(raw),
-			drop
-		})
-	}
-
 	#[inline]
 	pub fn name(&self) -> &str {
 		&self.name


### PR DESCRIPTION
cleaning up warnings. the debug! macro was defined but never called anywhere, outlet::from_raw was pub(crate) and never used. the format!/tostring imports in copy.rs are only needed behind gpu features so i cfg-gated them. also swapped the deprecated ::set-output in ci for the normal \ thing. 7 warnings to 1.