### PR TITLE
docs: add Air Paint to projects using ort

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ When you need to deploy a PyTorch/TensorFlow/Keras/scikit-learn/PaddlePaddle mod
 - **[SilentKeys](https://github.com/gptguy/silentkeys)** uses `ort` for fast, on-device real-time dictation with NVIDIA Parakeet and Silero VAD.
 - **[Xybrid](https://github.com/xybrid-ai/xybrid)** uses `ort` to run LLMs, ASR, and TTS natively on-device across iOS, Android, Flutter, and Unity apps and games.
 - **[Ultralytics YOLO Rust Inference](https://github.com/ultralytics/inference)** is a high-performance, pure Rust library and CLI providing fast and efficient interface for running YOLO models using `ort`.
+- **[Air Paint](https://github.com/RefinedDev/air_paint)** uses `ort` to run a YOLO hand pose model for real-time air drawing.


### PR DESCRIPTION
Hello,

Thanks for maintaining `ort`!

I'd like to add my project, [Air Paint](https://github.com/RefinedDev/air_paint), to the list of community projects using `ort`.

Air Paint is a simple application I built while learning AI/ML. It uses `ort` to run a YOLO hand pose model for real-time air drawing.

Thank you!