### PR TITLE
Fix preload_dylibs doc to pass doctest

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -55,7 +55,7 @@ pub use self::ndarray::ArrayExt;
 /// of the [CUDA execution provider](crate::ep::CUDA).
 ///
 /// ```
-/// use std::env;
+/// use std::env::current_exe;
 ///
 /// // Use the DirectML DLL we ship alongside the application.
 /// // This needs to come before we use any other `ort` API.


### PR DESCRIPTION
### Description

While testing with `cargo test --features fetch-models,load-dynamic` I ran into this error from a doctest:

```rust
---- src/util/mod.rs - util::preload_dylib (line 57) stdout ----
error[E0425]: cannot find function `current_exe` in this scope
  --> src/util/mod.rs:63:23
   |
63 | let application_dir = current_exe().unwrap();
   |                       ^^^^^^^^^^^ not found in this scope
   |
help: consider importing this function
   |
56 + use std::env::current_exe;
   |
```

A simple import path fix in the docs by adding `current_exe` to the end of `std::env`. 

If I am missing something or this is the wrong approach, I'd love to learn.

### Testing

Ran and passed tests with features `fetch-models` and `load-dynamic`.
