### PR TITLE
fix(load-dynamic): propagate version error msg for bad version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ fn setup_api() -> ApiPointer {
 				_ => "libonnxruntime.dylib".to_owned()
 			}
 			.into();
-			load_dynamic::init(&path).expect("Failed to load ONNX Runtime dylib");
+			load_dynamic::init(&path).unwrap_or_else(|e| panic!("Failed to load ONNX Runtime dylib: {e}"));
 			G_ORT_LIB.get_unchecked()
 		};
 		let base_getter: libloading::Symbol<unsafe extern "C" fn() -> *const ort_sys::OrtApiBase> = dylib


### PR DESCRIPTION
### Motivation

As someone trying to use this library with various versions of ONNX and ort, it would be nice if the bad version error message said what version it expects. 

#### Before
```Failed to load ONNX Runtime dylib: BadVersion { version_str: "1.24.2", path: "path/to/onnxruntime/lib/libonnxruntime.so.1.24.2" }```

#### After
```Failed to load ONNX Runtime dylib: ort 2.0.0-rc.13 is not compatible with the ONNX Runtime binary found at `path/to/onnxruntime/lib/libonnxruntime.so.1.24.2`; expected version >= '1.27.x', but got '1.24.2'```

If there's a better way to do this please let me know.

### Testing

Ran and successfully completed tests with features `fetch-models` and `load-dynamic`.
