### PR TITLE
fix(ort-sys): link model package in static builds

### DIFF
--- a/ort-sys/build/static_link/mod.rs
+++ b/ort-sys/build/static_link/mod.rs
@@ -156,6 +156,8 @@ pub fn static_link(base_lib_dir: &Path) -> bool {
 				}
 			}
 
+			optional_link_lib(&lib_dir.join("model_package"), "model_package");
+
 			if extension_lib_dir.exists() && extension_lib_dir.join(platform_format_lib("ortcustomops")).exists() {
 				add_search_dir(&extension_lib_dir);
 				println!("cargo:rustc-link-lib=static=ortcustomops");


### PR DESCRIPTION
Thanks for this amazing crate!

On my ubuntu 24 linux machine, ONNX Runtime 1.28's `libonnxruntime_session.a` references `ModelPackage_*` symbols, but `ort-sys` rc.13 does not link the separate `model_package/libmodel_package.a` archive for custom static builds, causing undefined-reference linker errors.