### PR TITLE
docs: with_disabled_optimizers takes a semicolon-separated list, not comma

### DIFF
--- a/src/session/builder/impl_config_keys.rs
+++ b/src/session/builder/impl_config_keys.rs
@@ -73,7 +73,25 @@ impl SessionBuilder {
 		self.with_config_entry("session.disable_aot_function_inlining", if enable { "0" } else { "1" })
 	}
 
-	/// Accepts a comma-separated list of optimizers to disable.
+	/// Accepts a **semicolon**-separated list of optimizers to disable.
+	///
+	/// Note that ONNX Runtime splits this value on `;`, not `,`
+	/// ([`inference_session.cc`](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/session/inference_session.cc)
+	/// calls `utils::SplitString(disabled_string, ";")`). A comma-joined list is treated as a
+	/// single optimizer name, matches nothing, and silently disables **no** optimizers.
+	///
+	/// Unrecognized names are also ignored without error, so a typo behaves exactly like not
+	/// calling this at all.
+	///
+	/// ```no_run
+	/// # use ort::session::Session;
+	/// # fn main() -> ort::Result<()> {
+	/// let session = Session::builder()?
+	/// 	.with_disabled_optimizers("ConstantFolding;GeluFusionL2")?
+	/// 	.commit_from_file("model.onnx")?;
+	/// # Ok(())
+	/// # }
+	/// ```
 	pub fn with_disabled_optimizers(self, optimizers: impl AsRef<str>) -> BuilderResult {
 		self.with_config_entry("optimization.disable_specified_optimizers", optimizers)
 	}

--- a/src/session/builder/impl_config_keys.rs
+++ b/src/session/builder/impl_config_keys.rs
@@ -73,15 +73,7 @@ impl SessionBuilder {
 		self.with_config_entry("session.disable_aot_function_inlining", if enable { "0" } else { "1" })
 	}
 
-	/// Accepts a **semicolon**-separated list of optimizers to disable.
-	///
-	/// Note that ONNX Runtime splits this value on `;`, not `,`
-	/// ([`inference_session.cc`](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/session/inference_session.cc)
-	/// calls `utils::SplitString(disabled_string, ";")`). A comma-joined list is treated as a
-	/// single optimizer name, matches nothing, and silently disables **no** optimizers.
-	///
-	/// Unrecognized names are also ignored without error, so a typo behaves exactly like not
-	/// calling this at all.
+	/// Accepts a semicolon-separated list of optimizers to disable.
 	///
 	/// ```
 	/// # use ort::session::Session;

--- a/src/session/builder/impl_config_keys.rs
+++ b/src/session/builder/impl_config_keys.rs
@@ -83,12 +83,13 @@ impl SessionBuilder {
 	/// Unrecognized names are also ignored without error, so a typo behaves exactly like not
 	/// calling this at all.
 	///
-	/// ```no_run
+	/// ```
 	/// # use ort::session::Session;
 	/// # fn main() -> ort::Result<()> {
-	/// let session = Session::builder()?
+	/// # let env = ort::test_util::test_env().clone();
+	/// let session = Session::builder(&env)?
 	/// 	.with_disabled_optimizers("ConstantFolding;GeluFusionL2")?
-	/// 	.commit_from_file("model.onnx")?;
+	/// 	.commit_from_file("tests/data/upsample.onnx")?;
 	/// # Ok(())
 	/// # }
 	/// ```


### PR DESCRIPTION
The doc comment on `with_disabled_optimizers` says "comma-separated". ONNX Runtime splits this config value on `;`.

From [`inference_session.cc`](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/session/inference_session.cc):

```cpp
auto disabled_string = session_options_.config_options.GetConfigOrDefault(
    kOrtSessionOptionsDisableSpecifiedOptimizers, "");
if (!disabled_string.empty()) {
  const auto disabled_list = utils::SplitString(disabled_string, ";");
```

So a comma-joined list is taken as a single optimizer name, matches nothing, and disables no optimizers at all.

What makes this worth fixing rather than noting is that it fails silently. ORT ignores unrecognized optimizer names without an error, so passing `"A,B"` produces a session that opens normally and behaves exactly as though the call had never been made. There is no warning and no way to tell from the outside.

I hit this while working around an ORT fusion problem on aarch64. I was passing a comma-separated list, saw no change in behaviour, and concluded the config entry did not work. It took a while to find that the list was fine and only the separator was wrong.

Measured on ort 2.0.0-rc.12 against ORT 1.24.2, using session load success as the signal:

```
disable "GeluFusionL2"                 model loads
disable "GeluFusionL1;GeluFusionL2"    model loads
disable "GeluFusionL1,GeluFusionL2"    model FAILS to load, so nothing was disabled
```

The change corrects the separator, adds an example, and documents the silent-ignore behaviour for unrecognized names, since that is the part that makes a wrong value hard to notice.

Docs only, no behaviour change.